### PR TITLE
Added MSVC version guards around noexcept() macro hack.

### DIFF
--- a/include/evmjit/JIT-c.h
+++ b/include/evmjit/JIT-c.h
@@ -8,8 +8,11 @@
 	#define EVMJIT_API __declspec(dllimport)
 #endif
 
+#if _MSC_VER < 1900
 #define _ALLOW_KEYWORD_MACROS
 #define noexcept throw()
+#endif // _MSC_VER < 1900
+
 #else
 #define EVMJIT_API [[gnu::visibility("default")]]
 #endif

--- a/include/evmjit/JIT.h
+++ b/include/evmjit/JIT.h
@@ -12,8 +12,11 @@
 	#define EVMJIT_API __declspec(dllimport)
 #endif
 
+#if _MSC_VER < 1900
 #define _ALLOW_KEYWORD_MACROS
 #define noexcept throw()
+#endif // _MSC_VER < 1900
+
 #else
 #define EVMJIT_API [[gnu::visibility("default")]]
 #endif


### PR DESCRIPTION
We only need that macro for pre-VS2015 VC++ compilers.
It actually breaks the build for VS2015.