### PR TITLE
Build LLVM from source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: cpp
+sudo: required
+dist: trusty
+compiler:
+  - gcc
+  - clang
+env:
+  - BUILD_TYPE=Release
+  - BUILD_TYPE=Debug
+cache:
+  - ccache
+  - directories: build/llvm
+
+
+before_install:
+  - sudo apt-add-repository -y ppa:george-edison55/cmake-3.x
+  - sudo apt-get -q update
+  - sudo apt-get -qy install cmake
+
+script:
+  - mkdir -p build && cd build
+  - cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE ..
+  - cmake --build .

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,14 @@ message(STATUS "EVM JIT ${EVMJIT_VERSION_MAJOR}.${EVMJIT_VERSION_MINOR}.${EVMJIT
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 set(CMAKE_AUTOMOC OFF)
 
-if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+	# Always use Release variant of C++ runtime.
+	# We don't want to provide Debug variants of all dependencies. Some default
+	# flags set by CMake must be tweaked.
+	string(REPLACE "/MDd" "/MD" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
+	string(REPLACE "/D_DEBUG" "" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
+	string(REPLACE "/RTC1" "" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
+	set_property(GLOBAL PROPERTY DEBUG_CONFIGURATIONS OFF)
 else()
 	set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wextra -Wconversion -Wno-sign-conversion -Wno-unknown-pragmas ${CMAKE_CXX_FLAGS}")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,16 +31,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND NOT SANITIZE)
 	set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-undefined")
 endif()
 
-# LLVM
-if (DEFINED APPLE)
-	set(LLVM_DIR "/usr/local/opt/llvm37/lib/llvm-3.7/share/llvm/cmake")
-endif()
-
-find_package(LLVM REQUIRED CONFIG)
-if (LLVM_VERSION VERSION_LESS 3.7)
-	message(FATAL_ERROR "Incompatible LLVM version ${LLVM_VERSION}")
-endif()
-message(STATUS "Using LLVM ${LLVM_VERSION} (${LLVM_DIR})")
-llvm_map_components_to_libnames(LLVM_LIBS core support mcjit x86asmparser x86codegen ipo)
+include(cmake/llvm.cmake)
+configure_llvm_project(llvm)
 
 add_subdirectory(libevmjit)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,16 @@
+version: "{build}"
+branches:
+  only:
+  - develop
+configuration:
+- Debug
+- Release
+cache: build/llvm
+before_build: |
+  if not exist build mkdir build
+  cd build
+  cmake -G "Visual Studio 14 2015 Win64" ..
+build:
+  project: c:/projects/evmjit/build/evmjit.sln
+  parallel: true
+  verbosity: minimal

--- a/circle.yml
+++ b/circle.yml
@@ -1,12 +1,15 @@
 dependencies:
-  override:
+  pre:
     - sudo apt-add-repository -y ppa:george-edison55/cmake-3.x
-    - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
-    - sudo add-apt-repository -y "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.7 main"
     - sudo apt -q update
-    - sudo apt -qy install cmake libedit-dev llvm-3.7-dev
+    - sudo apt -qy install cmake
+  override:
+    - mkdir -p build && cd build && cmake ..
+    - cmake --build build
+  cache_directories:
+    # TODO: add ccache
+    - build/llvm  # Cache llvm build
+
 test:
   override:
-    - mkdir build && cd $_
-    - cmake ../evmjit
-    - cmake --build .
+    - ldd build/libevmjit/libevmjit.so  # Just anything

--- a/cmake/llvm.cmake
+++ b/cmake/llvm.cmake
@@ -1,0 +1,89 @@
+
+# Configures LLVM dependency
+#
+# This function handles everything needed to setup LLVM project.
+# By default it downloads and builds LLVM from source.
+# In case LLVM_DIR variable is set it tries to use the pointed pre-built
+# LLVM package. LLVM_DIR should point LLVM's shared cmake files to be used
+# by find_package(... CONFIG) function.
+#
+# Creates a target representing all required LLVM libraries and include path.
+function(configure_llvm_project TARGET_NAME)
+    if (LLVM_DIR)
+        find_package(LLVM REQUIRED CONFIG)
+        llvm_map_components_to_libnames(LIBS mcjit ipo x86codegen)
+        # Try to get location of MCJIT lib on Windows (Release build)
+        get_property(MAIN_LIB TARGET LLVMMCJIT PROPERTY IMPORTED_LOCATION_RELEASE)
+        if (NOT MAIN_LIB)
+            # On Unix fallback to non-config location
+            get_property(MAIN_LIB TARGET LLVMMCJIT PROPERTY IMPORTED_LOCATION)
+        endif()
+        message(STATUS "LLVM ${LLVM_VERSION} (${LLVM_DIR})")
+    else()
+        # List of required LLVM libs.
+        # Generated with `llvm-config --libs mcjit ipo x86codegen`
+        # Only used here locally to setup the "llvm-libs" imported target
+        set(LIBS
+            LLVMMCJIT
+            LLVMX86CodeGen LLVMX86Desc LLVMX86Info LLVMMCDisassembler LLVMX86AsmPrinter
+            LLVMX86Utils LLVMSelectionDAG LLVMAsmPrinter LLVMCodeGen
+            LLVMInstrumentation LLVMBitWriter LLVMipo LLVMVectorize LLVMScalarOpts
+            LLVMProfileData LLVMIRReader LLVMAsmParser LLVMInstCombine
+            LLVMTransformUtils LLVMExecutionEngine LLVMTarget LLVMAnalysis
+            LLVMRuntimeDyld LLVMObject LLVMMCParser LLVMBitReader LLVMMC
+            LLVMCore LLVMSupport
+        )
+
+        # System libs that LLVM depend on.
+        # See `llvm-config --system-libs`
+        if (APPLE)
+            set(SYSTEM_LIBS pthread z m curses)
+        elseif (UNIX)
+            set(SYSTEM_LIBS pthread z m tinfo dl)
+        endif()
+
+        if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+            # Clang needs this to build LLVM. Weird that the GCC does not.
+            set(DEFINES __STDC_LIMIT_MACROS __STDC_CONSTANT_MACROS)
+        endif()
+
+        include(ExternalProject)
+        ExternalProject_Add(llvm-project
+            PREFIX llvm
+            BINARY_DIR llvm  # Build directly to install dir to avoid copy.
+            SOURCE_DIR llvm/src/llvm
+            URL http://llvm.org/releases/3.8.0/llvm-3.8.0.src.tar.xz
+            URL_HASH SHA256=555b028e9ee0f6445ff8f949ea10e9cd8be0d084840e21fbbe1d31d51fc06e46
+            CMAKE_ARGS -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+                       -DLLVM_TARGETS_TO_BUILD=X86
+                       -DLLVM_INCLUDE_TOOLS=OFF -DLLVM_INCLUDE_EXAMPLES=OFF
+                       -DLLVM_INCLUDE_TESTS=OFF
+            BUILD_COMMAND   cmake --build <BINARY_DIR> --config Release
+            INSTALL_COMMAND cmake --build <BINARY_DIR> --config Release --target install
+            EXCLUDE_FROM_ALL TRUE
+        )
+
+        ExternalProject_Get_Property(llvm-project INSTALL_DIR)
+        set(LLVM_LIBRARY_DIRS ${INSTALL_DIR}/lib)
+        set(LLVM_INCLUDE_DIRS ${INSTALL_DIR}/include)
+        file(MAKE_DIRECTORY ${LLVM_INCLUDE_DIRS})  # Must exists.
+
+        foreach(LIB ${LIBS})
+            list(APPEND LIBFILES "${LLVM_LIBRARY_DIRS}/${CMAKE_STATIC_LIBRARY_PREFIX}${LIB}${CMAKE_STATIC_LIBRARY_SUFFIX}")
+        endforeach()
+
+        # Pick one of the libraries to be the main one. It does not matter which one
+        # but the imported target requires the IMPORTED_LOCATION property.
+        list(GET LIBFILES 0 MAIN_LIB)
+        list(REMOVE_AT LIBFILES 0)
+        set(LIBS ${LIBFILES} ${SYSTEM_LIBS})
+    endif()
+
+    # Create the target representing
+    add_library(${TARGET_NAME} STATIC IMPORTED)
+    set_property(TARGET ${TARGET_NAME} PROPERTY INTERFACE_COMPILE_DEFINITIONS ${DEFINES})
+    set_property(TARGET ${TARGET_NAME} PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${LLVM_INCLUDE_DIRS})
+    set_property(TARGET ${TARGET_NAME} PROPERTY IMPORTED_LOCATION ${MAIN_LIB})
+    set_property(TARGET ${TARGET_NAME} PROPERTY IMPORTED_LINK_INTERFACE_LIBRARIES ${LIBS})
+    add_dependencies(${TARGET_NAME} llvm-project)
+endfunction()

--- a/libevmjit/CMakeLists.txt
+++ b/libevmjit/CMakeLists.txt
@@ -50,10 +50,8 @@ set_target_properties(${TARGET_NAME} PROPERTIES
 						FOLDER "libs")
 
 target_include_directories(${TARGET_NAME} PUBLIC ${EVMJIT_INCLUDE_DIR})
-target_include_directories(${TARGET_NAME} PRIVATE ${LLVM_INCLUDE_DIRS})
 target_include_directories(${TARGET_NAME} PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/gen)
-target_compile_definitions(${TARGET_NAME} PRIVATE ${LLVM_DEFINITIONS})
-target_link_libraries(${TARGET_NAME} PRIVATE ${LLVM_LIBS})
+target_link_libraries(${TARGET_NAME} PRIVATE llvm)
 
 install(TARGETS ${TARGET_NAME} LIBRARY DESTINATION lib ARCHIVE DESTINATION lib RUNTIME DESTINATION bin)
 install(DIRECTORY ${EVMJIT_INCLUDE_DIR} DESTINATION include)


### PR DESCRIPTION
Extend cmake scripts to build LLVM from source if a location of the LLVM not explicitly provided (by `-DLLVM_DIR` option).