### PR TITLE
EVM-C: Support multiple implementations

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_compile_options("-Wno-extra")  # Override -Wextra, I don't know better option.
+
 add_library(example-vm STATIC EXCLUDE_FROM_ALL examplevm.c)
 target_include_directories(example-vm PRIVATE ../include)
 

--- a/examples/capi.c
+++ b/examples/capi.c
@@ -65,8 +65,8 @@ int64_t call(
 int main(int argc, char *argv[]) {
     printf("Using VM: %s (%s)\n", evm_get_info(EVM_NAME), evm_get_info(EVM_VERSION));
 
-    struct evm_fn_table ftab = examplevm_get_fn_table();
-    struct evm_instance* jit = ftab.create(query, update, call);
+    struct evm_interface intf = examplevm_get_interface();
+    struct evm_instance* jit = intf.create(query, update, call);
 
     char const code[] = "exec()";
     const size_t code_size = sizeof(code);
@@ -76,7 +76,7 @@ int main(int argc, char *argv[]) {
 
     int64_t gas = 200000;
     struct evm_result result =
-        ftab.execute(jit, NULL, EVM_HOMESTEAD, code_hash, (const uint8_t *)code, code_size, gas, (const uint8_t *)input,
+        intf.execute(jit, NULL, EVM_HOMESTEAD, code_hash, (const uint8_t *)code, code_size, gas, (const uint8_t *)input,
                     sizeof(input), value);
 
     printf("Execution result:\n");
@@ -94,6 +94,6 @@ int main(int argc, char *argv[]) {
     }
     printf("\n");
 
-    ftab.release_result(&result);
-    ftab.destroy(jit);
+    intf.release_result(&result);
+    intf.destroy(jit);
 }

--- a/examples/capi.c
+++ b/examples/capi.c
@@ -1,11 +1,8 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <inttypes.h>
 #include "evm.h"
 
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma clang diagnostic ignored "-Wunused-parameter"
 
 struct evm_uint256 balance(struct evm_env* env, struct evm_hash160 address)
 {
@@ -86,8 +83,8 @@ int main(int argc, char *argv[]) {
     if (result.gas_left & EVM_EXCEPTION) {
       printf("  EVM eception\n");
     }
-    printf("  Gas used: " PRId64 "\n", gas - result.gas_left);
-    printf("  Gas left: " PRId64 "\n", result.gas_left);
+    printf("  Gas used: %ld\n", gas - result.gas_left);
+    printf("  Gas left: %ld\n", result.gas_left);
     printf("  Output size: %zd\n", result.output_size);
 
     printf("  Output: ");

--- a/examples/capi.c
+++ b/examples/capi.c
@@ -1,7 +1,11 @@
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <inttypes.h>
 #include "evm.h"
+
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wunused-parameter"
 
 struct evm_uint256 balance(struct evm_env* env, struct evm_hash160 address)
 {
@@ -64,7 +68,8 @@ int64_t call(
 int main(int argc, char *argv[]) {
     printf("Using VM: %s (%s)\n", evm_get_info(EVM_NAME), evm_get_info(EVM_VERSION));
 
-    struct evm_instance* jit = evm_create(query, update, call);
+    struct evm_fn_table ftab = examplevm_get_fn_table();
+    struct evm_instance* jit = ftab.create(query, update, call);
 
     char const code[] = "exec()";
     const size_t code_size = sizeof(code);
@@ -74,23 +79,24 @@ int main(int argc, char *argv[]) {
 
     int64_t gas = 200000;
     struct evm_result result =
-        evm_execute(jit, NULL, EVM_HOMESTEAD, code_hash, (const uint8_t *)code, code_size, gas, (const uint8_t *)input,
+        ftab.execute(jit, NULL, EVM_HOMESTEAD, code_hash, (const uint8_t *)code, code_size, gas, (const uint8_t *)input,
                     sizeof(input), value);
 
     printf("Execution result:\n");
     if (result.gas_left & EVM_EXCEPTION) {
       printf("  EVM eception\n");
     }
-    printf("  Gas used: %lld\n", gas - result.gas_left);
-    printf("  Gas left: %lld\n", result.gas_left);
+    printf("  Gas used: " PRId64 "\n", gas - result.gas_left);
+    printf("  Gas left: " PRId64 "\n", result.gas_left);
     printf("  Output size: %zd\n", result.output_size);
 
     printf("  Output: ");
-    for (int i = 0; i < result.output_size; i++) {
+    size_t i = 0;
+    for (i = 0; i < result.output_size; i++) {
         printf("%02x ", result.output_data[i]);
     }
     printf("\n");
 
-    evm_destroy_result(result);
-    evm_destroy(jit);
+    ftab.release_result(&result);
+    ftab.destroy(jit);
 }

--- a/examples/examplevm.c
+++ b/examples/examplevm.c
@@ -3,9 +3,6 @@
 #include <stdbool.h>
 #include "evm.h"
 
-#pragma GCC diagnostic ignored "-Wunused-parameter"
-#pragma clang diagnostic ignored "-Wunused-parameter"
-
 struct evm_instance {
     evm_query_fn query_fn;
     evm_update_fn update_fn;
@@ -70,7 +67,11 @@ static void evm_release_result(struct evm_result const* result)
 
 EXPORT struct evm_fn_table examplevm_get_fn_table()
 {
-    struct evm_fn_table ftab = {evm_create, evm_destroy, evm_execute,
-                                evm_release_result, 0, 0, 0};
+    struct evm_fn_table ftab;
+    memset(&ftab, 0, sizeof(struct evm_result));
+    ftab.create = evm_create;
+    ftab.destroy = evm_destroy;
+    ftab.execute = evm_execute;
+    ftab.release_result = evm_release_result;
     return ftab;
 }

--- a/examples/examplevm.c
+++ b/examples/examplevm.c
@@ -3,6 +3,9 @@
 #include <stdbool.h>
 #include "evm.h"
 
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma clang diagnostic ignored "-Wunused-parameter"
+
 struct evm_instance {
     evm_query_fn query_fn;
     evm_update_fn update_fn;
@@ -19,7 +22,7 @@ EXPORT char const* evm_get_info(enum evm_info_key key)
   return "";
 }
 
-EXPORT struct evm_instance* evm_create(evm_query_fn query_fn,
+static struct evm_instance* evm_create(evm_query_fn query_fn,
                                        evm_update_fn update_fn,
                                        evm_call_fn call_fn)
 {
@@ -34,19 +37,12 @@ EXPORT struct evm_instance* evm_create(evm_query_fn query_fn,
     return ret;
 }
 
-EXPORT void evm_destroy(struct evm_instance* evm)
+static void evm_destroy(struct evm_instance* evm)
 {
     free(evm);
 }
 
-EXPORT int evm_set_option(struct evm_instance* evm,
-                          char const* name,
-                          char const* value)
-{
-    return 0;
-}
-
-EXPORT struct evm_result evm_execute(struct evm_instance* instance,
+static struct evm_result evm_execute(struct evm_instance* instance,
                                      struct evm_env* env,
                                      enum evm_mode mode,
                                      struct evm_hash256 code_hash,
@@ -68,21 +64,13 @@ EXPORT struct evm_result evm_execute(struct evm_instance* instance,
     return ret;
 }
 
-EXPORT void evm_destroy_result(struct evm_result result)
+static void evm_release_result(struct evm_result const* result)
 {
 }
 
-EXPORT bool evmjit_is_code_ready(struct evm_instance* instance,
-                                 enum evm_mode mode,
-                                 struct evm_hash256 code_hash)
+EXPORT struct evm_fn_table examplevm_get_fn_table()
 {
-    return true;
-}
-
-EXPORT void evmjit_compile(struct evm_instance* instance,
-                           enum evm_mode mode,
-                           uint8_t const* code,
-                           size_t code_size,
-                           struct evm_hash256 code_hash)
-{
+    struct evm_fn_table ftab = {evm_create, evm_destroy, evm_execute,
+                                evm_release_result, 0, 0, 0};
+    return ftab;
 }

--- a/examples/examplevm.c
+++ b/examples/examplevm.c
@@ -76,14 +76,14 @@ static void evm_release_result(struct evm_result const* result)
 {
 }
 
-EXPORT struct evm_fn_table examplevm_get_fn_table()
+EXPORT struct evm_interface examplevm_get_interface()
 {
-    struct evm_fn_table ftab;
-    memset(&ftab, 0, sizeof(struct evm_result));
-    ftab.create = evm_create;
-    ftab.destroy = evm_destroy;
-    ftab.execute = evm_execute;
-    ftab.release_result = evm_release_result;
-    ftab.set_option = evm_set_option;
-    return ftab;
+    struct evm_interface intf;
+    memset(&intf, 0, sizeof(struct evm_result));
+    intf.create = evm_create;
+    intf.destroy = evm_destroy;
+    intf.execute = evm_execute;
+    intf.release_result = evm_release_result;
+    intf.set_option = evm_set_option;
+    return intf;
 }

--- a/examples/examplevm.c
+++ b/examples/examplevm.c
@@ -1,6 +1,5 @@
 #include <stdlib.h>
 #include <string.h>
-#include <stdbool.h>
 #include "evm.h"
 
 struct evm_instance {
@@ -39,6 +38,18 @@ static void evm_destroy(struct evm_instance* evm)
     free(evm);
 }
 
+/// Example options.
+///
+/// VMs are allowed to omit this function implementation.
+int evm_set_option(struct evm_instance* evm,
+                   char const* name,
+                   char const* value)
+{
+    if (strcmp(name, "example-option") == 0)
+        return 1;
+    return 0;
+}
+
 static struct evm_result evm_execute(struct evm_instance* instance,
                                      struct evm_env* env,
                                      enum evm_mode mode,
@@ -73,5 +84,6 @@ EXPORT struct evm_fn_table examplevm_get_fn_table()
     ftab.destroy = evm_destroy;
     ftab.execute = evm_execute;
     ftab.release_result = evm_release_result;
+    ftab.set_option = evm_set_option;
     return ftab;
 }

--- a/examples/examplevm.c
+++ b/examples/examplevm.c
@@ -39,11 +39,11 @@ EXPORT void evm_destroy(struct evm_instance* evm)
     free(evm);
 }
 
-EXPORT bool evm_set_option(struct evm_instance* evm,
-                           char const* name,
-                           char const* value)
+EXPORT int evm_set_option(struct evm_instance* evm,
+                          char const* name,
+                          char const* value)
 {
-    return false;
+    return 0;
 }
 
 EXPORT struct evm_result evm_execute(struct evm_instance* instance,

--- a/include/evm.h
+++ b/include/evm.h
@@ -244,6 +244,9 @@ enum evm_info_key {
 };
 
 /// Request information about the EVM implementation.
+/// FIXME: I don't think we need this, as we don't go towards fully dynamic
+///        solution (DLLs, dlopen()). User should know a priori what he is
+///        integrating with.
 ///
 /// @param key  What do you want to know?
 /// @return     Requested information as a c-string. Nonnull.
@@ -263,14 +266,14 @@ struct evm_instance;
 /// @param update_fn  Pointer to update callback function. Nonnull.
 /// @param call_fn    Pointer to call callback function. Nonnull.
 /// @return           Pointer to the created EVM instance.
-EXPORT struct evm_instance* evm_create(evm_query_fn query_fn,
-                                       evm_update_fn update_fn,
-                                       evm_call_fn call_fn);
+typedef struct evm_instance* (*evm_create_fn)(evm_query_fn query_fn,
+                                              evm_update_fn update_fn,
+                                              evm_call_fn call_fn);
 
 /// Destroys the EVM instance.
 ///
 /// @param evm  The EVM instance to be destroyed.
-EXPORT void evm_destroy(struct evm_instance* evm);
+typedef void (*evm_destroy_fn)(struct evm_instance* evm);
 
 
 /// Configures the EVM instance.
@@ -284,9 +287,9 @@ EXPORT void evm_destroy(struct evm_instance* evm);
 /// @param name   The option name. Cannot be null.
 /// @param value  The new option value. Cannot be null.
 /// @return       1 if the option set successfully, 0 otherwise.
-EXPORT int evm_set_option(struct evm_instance* evm,
-                          char const* name,
-                          char const* value);
+typedef int (*evm_set_option_fn)(struct evm_instance* evm,
+                                 char const* name,
+                                 char const* value);
 
 
 /// EVM compatibility mode aka chain mode.
@@ -316,16 +319,16 @@ enum evm_mode {
 /// @param input_size  The size of the input data.
 /// @param value       Call value.
 /// @return            All execution results.
-EXPORT struct evm_result evm_execute(struct evm_instance* instance,
-                                     struct evm_env* env,
-                                     enum evm_mode mode,
-                                     struct evm_hash256 code_hash,
-                                     uint8_t const* code,
-                                     size_t code_size,
-                                     int64_t gas,
-                                     uint8_t const* input,
-                                     size_t input_size,
-                                     struct evm_uint256 value);
+typedef struct evm_result (*evm_execute_fn)(struct evm_instance* instance,
+                                            struct evm_env* env,
+                                            enum evm_mode mode,
+                                            struct evm_hash256 code_hash,
+                                            uint8_t const* code,
+                                            size_t code_size,
+                                            int64_t gas,
+                                            uint8_t const* input,
+                                            size_t input_size,
+                                            struct evm_uint256 value);
 
 /// Releases resources assigned to an execution result.
 ///
@@ -335,7 +338,7 @@ EXPORT struct evm_result evm_execute(struct evm_instance* instance,
 /// @param result  The execution result which resource are to be released. The
 ///                result itself it not modified by this function, but becomes
 ///                invalid and user should discard it as well.
-EXPORT void evm_release_result(struct evm_result const* result);
+typedef void (*evm_release_result_fn)(struct evm_result const* result);
 
 /// Status of a code in VM. Useful for JIT-like implementations.
 enum evm_code_status {
@@ -351,18 +354,37 @@ enum evm_code_status {
 
 
 /// Get information the status of the code in the VM.
-EXPORT enum evm_code_status evm_get_code_status(struct evm_instance* instance,
-                                                enum evm_mode mode,
-                                                struct evm_hash256 code_hash);
+typedef enum evm_code_status
+(*evm_get_code_status_fn)(struct evm_instance* instance,
+                          enum evm_mode mode,
+                          struct evm_hash256 code_hash);
 
 /// Request preparation of the code for faster execution. It is not required
 /// to execute the code but allows compilation of the code ahead of time in
 /// JIT-like VMs.
-EXPORT void evm_prepare_code(struct evm_instance* instance,
-                             enum evm_mode mode,
-                             uint8_t const* code,
-                             size_t code_size,
-                             struct evm_hash256 code_hash);
+typedef void (*evm_prepare_code_fn)(struct evm_instance* instance,
+                                    enum evm_mode mode,
+                                    uint8_t const* code,
+                                    size_t code_size,
+                                    struct evm_hash256 code_hash);
+
+struct evm_fn_table {
+    evm_create_fn create;
+    evm_destroy_fn destroy;
+    evm_execute_fn execute;
+    evm_release_result_fn release_result;
+
+    /// Optional.
+    evm_get_code_status_fn get_code_status;
+
+    /// Optional.
+    evm_prepare_code_fn prepare_code;
+
+    /// Optional.
+    evm_set_option_fn set_option;
+};
+
+EXPORT struct evm_fn_table evmjit_get_fn_table();
 
 
 #if __cplusplus

--- a/include/evm.h
+++ b/include/evm.h
@@ -384,6 +384,10 @@ struct evm_fn_table {
     evm_set_option_fn set_option;
 };
 
+
+struct evm_fn_table examplevm_get_fn_table();
+
+
 EXPORT struct evm_fn_table evmjit_get_fn_table();
 
 

--- a/include/evm.h
+++ b/include/evm.h
@@ -368,27 +368,46 @@ typedef void (*evm_prepare_code_fn)(struct evm_instance* instance,
                                     size_t code_size,
                                     struct evm_hash256 code_hash);
 
+/// VM implementation's function table
+///
+/// Defines the implementation of EVM-C interface for a VM.
 struct evm_fn_table {
+    /// Pointer to function creating a VM's instance.
     evm_create_fn create;
+
+    /// Pointer to function destroying a VM's instance.
     evm_destroy_fn destroy;
+
+    /// Pointer to function execuing a code in a VM.
     evm_execute_fn execute;
+
+    /// Pointer to function releasing an execution result.
     evm_release_result_fn release_result;
 
-    /// Optional.
+    /// Optional pointer to function returning a status of a code.
+    ///
+    /// If the VM does not support this feature the pointer can be NULL.
     evm_get_code_status_fn get_code_status;
 
-    /// Optional.
+    /// Optional pointer to function compiling  a code.
+    ///
+    /// If the VM does not support this feature the pointer can be NULL.
     evm_prepare_code_fn prepare_code;
 
-    /// Optional.
+    /// Optional pointer to function modifying VM's options.
+    ///
+    /// If the VM does not support this feature the pointer can be NULL.
     evm_set_option_fn set_option;
 };
 
-
+/// Example of a function exporting a function table for an example VM.
+///
+/// Each VM implementation is obligates to provided a function returning
+/// a function table of type `evm_fn_table` defining VM's interface.
+/// The function has to be named as `<vm-name>_get_fn_table()`.
+///
+/// @return  Implementation's function table
 struct evm_fn_table examplevm_get_fn_table();
-
-
-EXPORT struct evm_fn_table evmjit_get_fn_table();
 
 
 #if __cplusplus

--- a/include/evm.h
+++ b/include/evm.h
@@ -12,7 +12,8 @@
 ///
 /// @defgroup EVMC EVM-C
 /// @{
-#pragma once
+#ifndef EVM_H
+#define EVM_H
 
 #include <stdint.h>    // Definition of int64_t, uint64_t.
 #include <stddef.h>    // Definition of size_t.
@@ -413,4 +414,6 @@ struct evm_fn_table examplevm_get_fn_table();
 #if __cplusplus
 }
 #endif
+
+#endif  // EVM_H
 /// @}

--- a/include/evm.h
+++ b/include/evm.h
@@ -16,7 +16,6 @@
 
 #include <stdint.h>    // Definition of int64_t, uint64_t.
 #include <stddef.h>    // Definition of size_t.
-#include <stdbool.h>   // Definition of bool.
 
 /// Allow implementation to inject some additional information about function
 /// linkage and/or symbol visibility in the output library.
@@ -284,10 +283,10 @@ EXPORT void evm_destroy(struct evm_instance* evm);
 /// @param evm    The EVM instance to be configured.
 /// @param name   The option name. Cannot be null.
 /// @param value  The new option value. Cannot be null.
-/// @return       True if the option set successfully.
-EXPORT bool evm_set_option(struct evm_instance* evm,
-                           char const* name,
-                           char const* value);
+/// @return       1 if the option set successfully, 0 otherwise.
+EXPORT int evm_set_option(struct evm_instance* evm,
+                          char const* name,
+                          char const* value);
 
 
 /// EVM compatibility mode aka chain mode.

--- a/include/evm.h
+++ b/include/evm.h
@@ -369,10 +369,10 @@ typedef void (*evm_prepare_code_fn)(struct evm_instance* instance,
                                     size_t code_size,
                                     struct evm_hash256 code_hash);
 
-/// VM implementation's function table
+/// VM interface.
 ///
 /// Defines the implementation of EVM-C interface for a VM.
-struct evm_fn_table {
+struct evm_interface {
     /// Pointer to function creating a VM's instance.
     evm_create_fn create;
 
@@ -401,14 +401,13 @@ struct evm_fn_table {
     evm_set_option_fn set_option;
 };
 
-/// Example of a function exporting a function table for an example VM.
+/// Example of a function exporting an interface for an example VM.
 ///
 /// Each VM implementation is obligates to provided a function returning
-/// a function table of type `evm_fn_table` defining VM's interface.
-/// The function has to be named as `<vm-name>_get_fn_table()`.
+/// VM's interface. The function has to be named as `<vm-name>_get_interface()`.
 ///
-/// @return  Implementation's function table
-struct evm_fn_table examplevm_get_fn_table();
+/// @return  VM interface
+struct evm_interface examplevm_get_interface();
 
 
 #if __cplusplus

--- a/include/evmjit.h
+++ b/include/evmjit.h
@@ -18,10 +18,10 @@
 extern "C" {
 #endif
 
-/// Get EVMJIT's function table for EVM-C interface.
+/// Get EVMJIT's EVM-C interface.
 ///
 /// @return  EVMJIT's function table.
-EXPORT struct evm_fn_table evmjit_get_fn_table();
+EXPORT struct evm_interface evmjit_get_interface();
 
 #if __cplusplus
 }

--- a/include/evmjit.h
+++ b/include/evmjit.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#ifdef _MSC_VER
+#ifdef evmjit_EXPORTS
+#define EXPORT __declspec(dllexport)
+#else
+#define EXPORT __declspec(dllimport)
+#endif
+
+#else
+#define EXPORT [[gnu::visibility("default")]]
+#endif
+
+// FIXME: evm.h uses EXPORT temporary.
+#include <evm.h>
+
+#if __cplusplus
+extern "C" {
+#endif
+
+/// Get EVMJIT's function table for EVM-C interface.
+///
+/// @return  EVMJIT's function table.
+EXPORT struct evm_fn_table evmjit_get_fn_table();
+
+#if __cplusplus
+}
+#endif

--- a/include/evmjit/JIT.h
+++ b/include/evmjit/JIT.h
@@ -5,23 +5,7 @@
 #include <functional>
 #include <type_traits>
 
-#ifdef _MSC_VER
-#ifdef evmjit_EXPORTS
-#define EXPORT __declspec(dllexport)
-#else
-#define EXPORT __declspec(dllimport)
-#endif
-
-#else
-#define EXPORT [[gnu::visibility("default")]]
-#endif
-
-#include <evm.h>  // Uses EXPORT macro
-
-#if _MSC_VER && _MSC_VER < 1900
-#define _ALLOW_KEYWORD_MACROS
-#define noexcept throw()
-#endif
+#include <evmjit.h>
 
 namespace dev
 {

--- a/libevmjit/JIT.cpp
+++ b/libevmjit/JIT.cpp
@@ -265,6 +265,7 @@ static evm_instance* create(evm_query_fn queryFn, evm_update_fn updateFn,
 
 static void destroy(evm_instance* instance)
 {
+    (void)instance;
 	assert(instance == static_cast<void*>(&JITImpl::instance()));
 }
 

--- a/libevmjit/JIT.cpp
+++ b/libevmjit/JIT.cpp
@@ -354,7 +354,7 @@ static void prepare_code(evm_instance* instance, evm_mode mode,
 		jit.mapExecFunc(codeIdentifier, execFunc);
 }
 
-EXPORT evm_fn_table evmjit_get_fn_table()
+EXPORT evm_interface evmjit_get_interface()
 {
 	return {create, destroy, execute, release_result, get_code_status, prepare_code, set_option};
 }

--- a/libevmjit/JIT.cpp
+++ b/libevmjit/JIT.cpp
@@ -325,11 +325,11 @@ EXPORT void evm_release_result(evm_result const* result)
 		ext_free(result->internal_memory);  // FIXME: Check what is ext_free about.
 }
 
-EXPORT bool evm_set_option(evm_instance* instance, char const* name,
+EXPORT int evm_set_option(evm_instance* instance, char const* name,
 	char const* value)
 {
 	(void)instance, (void)name, (void)value;
-	return false;
+	return 0;
 }
 
 EXPORT evm_code_status evm_get_code_status(evm_instance* instance,

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,3 +4,4 @@ set -x -e
 mkdir -p build && cd build
 cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DEVMJIT_INCLUDE_EXAMPLES=On ..
 cmake --build .
+cmake --build . --target example-capi


### PR DESCRIPTION
Support multiple VM implementations by EVM-C in a single application by exporting only a function table (like vtable in OOP) for each implementation. The symbol name convention is `<vm-name>_get_fn_table()`.