### PR TITLE
EVM-C: Extend evm_result

### DIFF
--- a/examples/capi.c
+++ b/examples/capi.c
@@ -80,19 +80,20 @@ int main(int argc, char *argv[]) {
                     sizeof(input), value);
 
     printf("Execution result:\n");
-    if (result.outcome == EVM_EXCEPTION) {
-      printf("  EVM exception\n");
-    }
-    printf("  Gas used: %ld\n", gas - result.gas_left);
-    printf("  Gas left: %ld\n", result.gas_left);
-    printf("  Output size: %zd\n", result.output_size);
+    if (result.outcome != EVM_SUCCESS) {
+      printf("  EVM execution failure: %d\n", result.outcome);
+    } else {
+        printf("  Gas used: %ld\n", gas - result.gas_left);
+        printf("  Gas left: %ld\n", result.gas_left);
+        printf("  Output size: %zd\n", result.output_size);
 
-    printf("  Output: ");
-    size_t i = 0;
-    for (i = 0; i < result.output_size; i++) {
-        printf("%02x ", result.output_data[i]);
+        printf("  Output: ");
+        size_t i = 0;
+        for (i = 0; i < result.output_size; i++) {
+            printf("%02x ", result.output_data[i]);
+        }
+        printf("\n");
     }
-    printf("\n");
 
     intf.release_result(&result);
     intf.destroy(jit);

--- a/examples/capi.c
+++ b/examples/capi.c
@@ -80,8 +80,8 @@ int main(int argc, char *argv[]) {
                     sizeof(input), value);
 
     printf("Execution result:\n");
-    if (result.outcome != EVM_SUCCESS) {
-      printf("  EVM execution failure: %d\n", result.outcome);
+    if (result.error_code != EVM_SUCCESS) {
+      printf("  EVM execution failure: %d\n", result.error_code);
     } else {
         printf("  Gas used: %ld\n", gas - result.gas_left);
         printf("  Gas left: %ld\n", result.gas_left);

--- a/examples/capi.c
+++ b/examples/capi.c
@@ -80,8 +80,8 @@ int main(int argc, char *argv[]) {
                     sizeof(input), value);
 
     printf("Execution result:\n");
-    if (result.gas_left & EVM_EXCEPTION) {
-      printf("  EVM eception\n");
+    if (result.outcome == EVM_RESULT_EXCEPTION) {
+      printf("  EVM exception\n");
     }
     printf("  Gas used: %ld\n", gas - result.gas_left);
     printf("  Gas left: %ld\n", result.gas_left);

--- a/examples/capi.c
+++ b/examples/capi.c
@@ -80,8 +80,8 @@ int main(int argc, char *argv[]) {
                     sizeof(input), value);
 
     printf("Execution result:\n");
-    if (result.error_code != EVM_SUCCESS) {
-      printf("  EVM execution failure: %d\n", result.error_code);
+    if (result.code != EVM_SUCCESS) {
+      printf("  EVM execution failure: %d\n", result.code);
     } else {
         printf("  Gas used: %ld\n", gas - result.gas_left);
         printf("  Gas left: %ld\n", result.gas_left);

--- a/examples/capi.c
+++ b/examples/capi.c
@@ -58,7 +58,7 @@ int64_t call(
 )
 {
     printf("EVM-C: CALL %d\n", _kind);
-    return EVM_EXCEPTION;
+    return EVM_CALL_FAILURE;
 }
 
 /// Example how the API is supposed to be used.

--- a/examples/capi.c
+++ b/examples/capi.c
@@ -80,7 +80,7 @@ int main(int argc, char *argv[]) {
                     sizeof(input), value);
 
     printf("Execution result:\n");
-    if (result.outcome == EVM_RESULT_EXCEPTION) {
+    if (result.outcome == EVM_EXCEPTION) {
       printf("  EVM exception\n");
     }
     printf("  Gas used: %ld\n", gas - result.gas_left);

--- a/examples/examplevm.c
+++ b/examples/examplevm.c
@@ -67,7 +67,7 @@ static struct evm_result evm_execute(struct evm_instance* instance,
 
     // Execute code and refer to callbacks: instance->query_fn()
 
-    ret.outcome = EVM_RESULT_EXCEPTION;
+    ret.outcome = EVM_EXCEPTION;
     ret.gas_left = 0;
 
     return ret;

--- a/examples/examplevm.c
+++ b/examples/examplevm.c
@@ -67,6 +67,7 @@ static struct evm_result evm_execute(struct evm_instance* instance,
 
     // Execute code and refer to callbacks: instance->query_fn()
 
+    ret.outcome = EVM_RESULT_EXCEPTION;
     ret.gas_left = 0;
 
     return ret;

--- a/examples/examplevm.c
+++ b/examples/examplevm.c
@@ -67,7 +67,7 @@ static struct evm_result evm_execute(struct evm_instance* instance,
 
     // Execute code and refer to callbacks: instance->query_fn()
 
-    ret.error_code = EVM_FAILURE;
+    ret.code = EVM_FAILURE;
     ret.gas_left = 0;
 
     return ret;

--- a/examples/examplevm.c
+++ b/examples/examplevm.c
@@ -67,7 +67,7 @@ static struct evm_result evm_execute(struct evm_instance* instance,
 
     // Execute code and refer to callbacks: instance->query_fn()
 
-    ret.outcome = EVM_EXCEPTION;
+    ret.error_code = EVM_FAILURE;
     ret.gas_left = 0;
 
     return ret;

--- a/include/evm.h
+++ b/include/evm.h
@@ -61,13 +61,13 @@ struct evm_hash256 {
 
 /// The outcome of an execution.
 enum evm_result_outcome {
-    EVM_RESULT_SUCCESS = 0,
-    EVM_RESULT_OUT_OF_GAS = 1,
-    EVM_RESULT_BAD_INSTRUCTION = 2,
-    EVM_RESULT_BAD_JUMP_DESTINATION = 3,
-    EVM_RESULT_STACK_OVERFLOW = 4,
-    EVM_RESULT_STACK_UNDERFLOW = 5,
-    EVM_RESULT_EXCEPTION = 6
+    EVM_SUCCESS = 0,
+    EVM_OUT_OF_GAS = 1,
+    EVM_BAD_INSTRUCTION = 2,
+    EVM_BAD_JUMP_DESTINATION = 3,
+    EVM_STACK_OVERFLOW = 4,
+    EVM_STACK_UNDERFLOW = 5,
+    EVM_EXCEPTION = 6
 };
 
 /// Complex struct representing execution result.

--- a/include/evm.h
+++ b/include/evm.h
@@ -59,10 +59,10 @@ struct evm_hash256 {
     };
 };
 
-/// The outcome of an execution.
+/// The result error code.
 enum evm_result_error_code {
-    EVM_SUCCESS = 0,
-    EVM_FAILURE = 1,
+    EVM_SUCCESS = 0,               ///< Execution finished with success.
+    EVM_FAILURE = 1,               ///< Generic execution failure.
     EVM_OUT_OF_GAS = 2,
     EVM_BAD_INSTRUCTION = 3,
     EVM_BAD_JUMP_DESTINATION = 4,
@@ -77,17 +77,18 @@ struct evm_result {
 
     /// The amount of gas left after the execution.
     ///
-    /// The value is valid only if error_code == ::EVM_SUCCESS.
+    /// The value is valid only if
+    /// evm_result_error_code::error_code == evm_result_error_code::EVM_SUCCESS.
     int64_t gas_left;
 
     /// The rerefence to output data. The memory containing the output data
-    /// is owned by EVM and is freed with evm_release_result().
+    /// is owned by EVM and is freed with evm_release_result_fn().
     uint8_t const* output_data;
 
     /// The size of the output data.
     size_t output_size;
 
-    /// @defgroup Optional
+    /// @name Optional
     /// The optional information that EVM is not required to provide.
     /// @{
 

--- a/include/evm.h
+++ b/include/evm.h
@@ -59,9 +59,6 @@ struct evm_hash256 {
     };
 };
 
-
-#define EVM_EXCEPTION INT64_MIN  ///< The execution ended with an exception.
-
 /// The outcome of an execution.
 enum evm_result_outcome {
     EVM_RESULT_SUCCESS = 0,
@@ -219,6 +216,9 @@ enum evm_call_kind {
     EVM_CALLCODE = 2,     ///< Request CALLCODE.
     EVM_CREATE = 3        ///< Request CREATE. Semantic of some params changes.
 };
+
+/// This is used as a result code with evm_call_fn.
+#define EVM_EXCEPTION INT64_MIN  ///< The execution ended with an exception.
 
 /// Pointer to the callback function supporting EVM calls.
 ///

--- a/include/evm.h
+++ b/include/evm.h
@@ -62,9 +62,24 @@ struct evm_hash256 {
 
 #define EVM_EXCEPTION INT64_MIN  ///< The execution ended with an exception.
 
+/// The outcome of an execution.
+enum evm_result_outcome {
+    EVM_RESULT_SUCCESS = 0,
+    EVM_RESULT_OUT_OF_GAS = 1,
+    EVM_RESULT_BAD_INSTRUCTION = 2,
+    EVM_RESULT_EXCEPTION = 3
+};
+
 /// Complex struct representing execution result.
 struct evm_result {
-    /// Gas left after execution or exception indicator.
+    /// The outcome of the execution.
+    enum evm_result_outcome outcome;
+
+    /// Optional reason why the execution didn't succeed.
+    /// @see outcome.
+    const char *outcome_reason;
+
+    /// Gas left after execution.
     int64_t gas_left;
 
     /// Rerefence to output data. The memory containing the output data

--- a/include/evm.h
+++ b/include/evm.h
@@ -64,7 +64,10 @@ enum evm_result_outcome {
     EVM_RESULT_SUCCESS = 0,
     EVM_RESULT_OUT_OF_GAS = 1,
     EVM_RESULT_BAD_INSTRUCTION = 2,
-    EVM_RESULT_EXCEPTION = 3
+    EVM_RESULT_BAD_JUMP_DESTINATION = 3,
+    EVM_RESULT_STACK_OVERFLOW = 4,
+    EVM_RESULT_STACK_UNDERFLOW = 5,
+    EVM_RESULT_EXCEPTION = 6
 };
 
 /// Complex struct representing execution result.

--- a/include/evm.h
+++ b/include/evm.h
@@ -59,8 +59,8 @@ struct evm_hash256 {
     };
 };
 
-/// The result error code.
-enum evm_result_error_code {
+/// The execution result code.
+enum evm_result_code {
     EVM_SUCCESS = 0,               ///< Execution finished with success.
     EVM_FAILURE = 1,               ///< Generic execution failure.
     EVM_OUT_OF_GAS = 2,
@@ -72,16 +72,15 @@ enum evm_result_error_code {
 
 /// The EVM code execution result.
 struct evm_result {
-    /// The result error code.
-    enum evm_result_error_code error_code;
+    /// The execution result code.
+    enum evm_result_code code;
 
     /// The amount of gas left after the execution.
     ///
-    /// The value is valid only if
-    /// evm_result_error_code::error_code == evm_result_error_code::EVM_SUCCESS.
+    /// The value is valid only if evm_result::code == ::EVM_SUCCESS.
     int64_t gas_left;
 
-    /// The rerefence to output data. The memory containing the output data
+    /// The reference to output data. The memory containing the output data
     /// is owned by EVM and is freed with evm_release_result_fn().
     uint8_t const* output_data;
 
@@ -96,7 +95,7 @@ struct evm_result {
     /// @see output_data.
     void* internal_memory;
 
-    /// The error message explaining the error_code.
+    /// The error message explaining the result code.
     char const* error_message;
 
     /// @}

--- a/include/evm.h
+++ b/include/evm.h
@@ -60,43 +60,45 @@ struct evm_hash256 {
 };
 
 /// The outcome of an execution.
-enum evm_result_outcome {
-    EVM_SUCCESS = 1,
+enum evm_result_error_code {
+    EVM_SUCCESS = 0,
+    EVM_FAILURE = 1,
     EVM_OUT_OF_GAS = 2,
     EVM_BAD_INSTRUCTION = 3,
     EVM_BAD_JUMP_DESTINATION = 4,
     EVM_STACK_OVERFLOW = 5,
     EVM_STACK_UNDERFLOW = 6,
-    EVM_EXCEPTION = 7
 };
 
-/// Complex struct representing execution result.
+/// The EVM code execution result.
 struct evm_result {
-    /// The outcome of the execution.
-    enum evm_result_outcome outcome;
+    /// The result error code.
+    enum evm_result_error_code error_code;
 
-    /// Optional reason why the execution didn't succeed.
-    /// @see outcome.
-    const char *outcome_reason;
-
-    /// The last program counter position
-    /// It can be optionally present when certain conditions are hit.
-    /// @see outcome.
-    int32_t last_pc;
-
-    /// Gas left after execution.
+    /// The amount of gas left after the execution.
+    ///
+    /// The value is valid only if error_code == ::EVM_SUCCESS.
     int64_t gas_left;
 
-    /// Rerefence to output data. The memory containing the output data
-    /// is owned by EVM and is freed with evm_destroy_result().
+    /// The rerefence to output data. The memory containing the output data
+    /// is owned by EVM and is freed with evm_release_result().
     uint8_t const* output_data;
 
-    /// Size of the output data.
+    /// The size of the output data.
     size_t output_size;
 
-    /// Pointer to EVM-owned memory.
+    /// @defgroup Optional
+    /// The optional information that EVM is not required to provide.
+    /// @{
+
+    /// The pointer to EVM-owned memory. For EVM internal use.
     /// @see output_data.
     void* internal_memory;
+
+    /// The error message explaining the error_code.
+    char const* error_message;
+
+    /// @}
 };
 
 /// The query callback key.

--- a/include/evm.h
+++ b/include/evm.h
@@ -61,13 +61,13 @@ struct evm_hash256 {
 
 /// The outcome of an execution.
 enum evm_result_outcome {
-    EVM_SUCCESS = 0,
-    EVM_OUT_OF_GAS = 1,
-    EVM_BAD_INSTRUCTION = 2,
-    EVM_BAD_JUMP_DESTINATION = 3,
-    EVM_STACK_OVERFLOW = 4,
-    EVM_STACK_UNDERFLOW = 5,
-    EVM_EXCEPTION = 6
+    EVM_SUCCESS = 1,
+    EVM_OUT_OF_GAS = 2,
+    EVM_BAD_INSTRUCTION = 3,
+    EVM_BAD_JUMP_DESTINATION = 4,
+    EVM_STACK_OVERFLOW = 5,
+    EVM_STACK_UNDERFLOW = 6,
+    EVM_EXCEPTION = 7
 };
 
 /// Complex struct representing execution result.

--- a/include/evm.h
+++ b/include/evm.h
@@ -227,8 +227,8 @@ enum evm_call_kind {
     EVM_CREATE = 3        ///< Request CREATE. Semantic of some params changes.
 };
 
-/// This is used as a result code with evm_call_fn.
-#define EVM_CALL_FAILURE INT64_MIN  ///< The execution ended with a failure.
+/// The flag indicating call failure in evm_call_fn().
+static const int64_t EVM_CALL_FAILURE = INT64_MIN;
 
 /// Pointer to the callback function supporting EVM calls.
 ///

--- a/include/evm.h
+++ b/include/evm.h
@@ -226,7 +226,7 @@ enum evm_call_kind {
 };
 
 /// This is used as a result code with evm_call_fn.
-#define EVM_EXCEPTION INT64_MIN  ///< The execution ended with an exception.
+#define EVM_CALL_FAILURE INT64_MIN  ///< The execution ended with a failure.
 
 /// Pointer to the callback function supporting EVM calls.
 ///

--- a/include/evm.h
+++ b/include/evm.h
@@ -76,6 +76,11 @@ struct evm_result {
     /// @see outcome.
     const char *outcome_reason;
 
+    /// The last program counter position
+    /// It can be optionally present when certain conditions are hit.
+    /// @see outcome.
+    int32_t last_pc;
+
     /// Gas left after execution.
     int64_t gas_left;
 

--- a/libevmjit/Compiler.cpp
+++ b/libevmjit/Compiler.cpp
@@ -749,7 +749,7 @@ void Compiler::compileBasicBlock(BasicBlock& _basicBlock, RuntimeManager& _runti
 			auto ret =
 				m_builder.CreateICmpSGE(r, m_builder.getInt64(0), "create.ret");
 			auto rmagic = m_builder.CreateSelect(
-				ret, m_builder.getInt64(0), m_builder.getInt64(EVM_EXCEPTION),
+				ret, m_builder.getInt64(0), m_builder.getInt64(EVM_CALL_FAILURE),
 				"call.rmagic");
 			// TODO: optimize
 			auto finalCost = m_builder.CreateSub(r, rmagic, "create.finalcost");
@@ -811,7 +811,7 @@ void Compiler::compileBasicBlock(BasicBlock& _basicBlock, RuntimeManager& _runti
 			auto ret =
 				m_builder.CreateICmpSGE(r, m_builder.getInt64(0), "call.ret");
 			auto rmagic = m_builder.CreateSelect(
-				ret, m_builder.getInt64(0), m_builder.getInt64(EVM_EXCEPTION),
+				ret, m_builder.getInt64(0), m_builder.getInt64(EVM_CALL_FAILURE),
 				"call.rmagic");
 			// TODO: optimize
 			auto finalCost = m_builder.CreateSub(r, rmagic, "call.finalcost");

--- a/libevmjit/JIT.cpp
+++ b/libevmjit/JIT.cpp
@@ -286,7 +286,7 @@ static evm_result execute(evm_instance* instance, evm_env* env,
 	ExecutionContext ctx{rt, env};
 
 	evm_result result;
-	result.outcome = EVM_RESULT_EXCEPTION;
+	result.outcome = EVM_EXCEPTION;
 	result.gas_left = 0;
 	result.output_data = nullptr;
 	result.output_size = 0;
@@ -314,10 +314,10 @@ static evm_result execute(evm_instance* instance, evm_env* env,
 		}
 		case ReturnCode::Stop:
 			result.gas_left = rt.gas;
-			result.outcome = EVM_RESULT_SUCCESS;
+			result.outcome = EVM_SUCCESS;
 			break;
 		case ReturnCode:OutOfGas:
-			result.outcome = EVM_RESULT_OUT_OF_GAS;
+			result.outcome = EVM_OUT_OF_GAS;
 			break;
 		default:
 			break;

--- a/libevmjit/JIT.cpp
+++ b/libevmjit/JIT.cpp
@@ -286,7 +286,7 @@ static evm_result execute(evm_instance* instance, evm_env* env,
 	ExecutionContext ctx{rt, env};
 
 	evm_result result;
-	result.error_code = EVM_SUCCESS;
+	result.code = EVM_SUCCESS;
 	result.gas_left = 0;
 	result.output_data = nullptr;
 	result.output_size = 0;
@@ -308,7 +308,7 @@ static evm_result execute(evm_instance* instance, evm_env* env,
 	{
 		// EVMJIT does not provide information what exactly type of failure
 		// it was, so use generic EVM_FAILURE.
-		result.error_code = EVM_FAILURE;
+		result.code = EVM_FAILURE;
 	}
 	else
 	{

--- a/libevmjit/JIT.cpp
+++ b/libevmjit/JIT.cpp
@@ -286,7 +286,8 @@ static evm_result execute(evm_instance* instance, evm_env* env,
 	ExecutionContext ctx{rt, env};
 
 	evm_result result;
-	result.gas_left = EVM_EXCEPTION;
+	result.error_code = EVM_SUCCESS;
+	result.gas_left = 0;
 	result.output_data = nullptr;
 	result.output_size = 0;
 	result.internal_memory = nullptr;
@@ -303,8 +304,17 @@ static evm_result execute(evm_instance* instance, evm_env* env,
 
 	auto returnCode = execFunc(&ctx);
 
-	if (returnCode != ReturnCode::OutOfGas)
+	if (returnCode == ReturnCode::OutOfGas)
+	{
+		// EVMJIT does not provide information what exactly type of failure
+		// it was, so use generic EVM_FAILURE.
+		result.error_code = EVM_FAILURE;
+	}
+	else
+	{
+		// In case of success return the amount of gas left.
 		result.gas_left = rt.gas;
+	}
 
 	if (returnCode == ReturnCode::Return)
 	{

--- a/libevmjit/evmjit.cpp
+++ b/libevmjit/evmjit.cpp
@@ -3,7 +3,7 @@
 static_assert(sizeof(evm_uint256) == 32, "evm_uint256 is too big");
 static_assert(sizeof(evm_hash256) == 32, "evm_hash256 is too big");
 static_assert(sizeof(evm_hash160) == 20, "evm_hash160 is too big");
-static_assert(sizeof(evm_result) == 32, "evm_result is too big");
+static_assert(sizeof(evm_result) <= 64, "evm_result does not fit cache line");
 
 // Check enums match int size.
 // On GCC/clang the underlying type should be unsigned int, on MSVC int


### PR DESCRIPTION
This modifies some details of #81 to be aligned with my vision.

1. `EVM_FAILURE` is generic failure code.
2. Moved optional `evm_result` members to the bottom.
3. Removed `last_pc` from `evm_result`. I think we will be adding VM tracing support soon. Tracing will need a structure representing current state of execution -- information like PC, opcode, gas cost, gas, etc. It would be nice to include (optionally) this diagnostic structure in `evm_result` representing the last VM state. 