### PR TITLE
Do not use realloc/free wrappers

### DIFF
--- a/libevmjit/Array.cpp
+++ b/libevmjit/Array.cpp
@@ -153,7 +153,7 @@ llvm::Function* Array::createFreeFunc()
 	func->setDoesNotThrow();
 	func->setDoesNotCapture(1);
 
-	auto freeFunc = llvm::Function::Create(llvm::FunctionType::get(Type::Void, Type::BytePtr, false), llvm::Function::ExternalLinkage, "ext_free", getModule());
+	auto freeFunc = llvm::Function::Create(llvm::FunctionType::get(Type::Void, Type::BytePtr, false), llvm::Function::ExternalLinkage, "free", getModule());
 	freeFunc->setDoesNotThrow();
 	freeFunc->setDoesNotCapture(1);
 
@@ -172,11 +172,11 @@ llvm::Function* Array::createFreeFunc()
 
 llvm::Function* Array::getReallocFunc()
 {
-	if (auto func = getModule()->getFunction("ext_realloc"))
+	if (auto func = getModule()->getFunction("realloc"))
 		return func;
 
 	llvm::Type* reallocArgTypes[] = {Type::BytePtr, Type::Size};
-	auto reallocFunc = llvm::Function::Create(llvm::FunctionType::get(Type::BytePtr, reallocArgTypes, false), llvm::Function::ExternalLinkage, "ext_realloc", getModule());
+	auto reallocFunc = llvm::Function::Create(llvm::FunctionType::get(Type::BytePtr, reallocArgTypes, false), llvm::Function::ExternalLinkage, "realloc", getModule());
 	reallocFunc->setDoesNotThrow();
 	reallocFunc->setDoesNotAlias(0);
 	reallocFunc->setDoesNotCapture(1);
@@ -259,17 +259,4 @@ void Array::extend(llvm::Value* _arrayPtr, llvm::Value* _size)
 
 }
 }
-}
-
-extern "C"
-{
-	EXPORT void* ext_realloc(void* _data, size_t _size) noexcept
-	{
-		return std::realloc(_data, _size);
-	}
-
-	EXPORT void ext_free(void* _data) noexcept
-	{
-		std::free(_data);
-	}
 }

--- a/libevmjit/JIT.cpp
+++ b/libevmjit/JIT.cpp
@@ -237,12 +237,10 @@ ExecFunc JITImpl::compile(evm_mode _mode, byte const* _code, uint64_t _codeSize,
 } // anonymous namespace
 
 
-extern "C" void ext_free(void* _data) noexcept;
-
 ExecutionContext::~ExecutionContext() noexcept
 {
 	if (m_memData)
-		ext_free(m_memData); // Use helper free to check memory leaks
+		std::free(m_memData); // Use helper free to check memory leaks
 }
 
 bytes_ref ExecutionContext::getReturnData() const
@@ -346,7 +344,7 @@ static evm_result execute(evm_instance* instance, evm_env* env, evm_mode mode,
 static void release_result(evm_result const* result)
 {
 	if (result->internal_memory)
-		ext_free(result->internal_memory);  // FIXME: Check what is ext_free about.
+		std::free(result->internal_memory);
 }
 
 static int set_option(evm_instance* instance, char const* name,


### PR DESCRIPTION
They used to detect memory leaks. Replace with original names from C library, because symbols in evmjit.so are not visible by Python extensions (probably loaded with dlopen()).