### PR TITLE
Fix BLOCKHASH() for numbers bigger than int64

### DIFF
--- a/libevmjit/Compiler.cpp
+++ b/libevmjit/Compiler.cpp
@@ -666,7 +666,13 @@ void Compiler::compileBasicBlock(BasicBlock& _basicBlock, RuntimeManager& _runti
 		case Instruction::BLOCKHASH:
 		{
 			auto number = stack.pop();
+			// If number bigger than int64 assume the result is 0.
+			auto limitC = m_builder.getInt64(std::numeric_limits<int64_t>::max());
+			auto limit = m_builder.CreateZExt(limitC, Type::Word);
+			auto isBigNumber = m_builder.CreateICmpUGT(number, limit);
 			auto hash = _ext.blockHash(number);
+			// TODO: Try to eliminate the call if the number is invalid.
+			hash = m_builder.CreateSelect(isBigNumber, Constant::get(0), hash);
 			stack.push(hash);
 			break;
 		}


### PR DESCRIPTION
The host application assumes the VM will use arguments of type int64, so we need to check if the number is not bigger.

Fixes #52.