### PR TITLE
EVM-C v4

### DIFF
--- a/examples/capi.c
+++ b/examples/capi.c
@@ -51,15 +51,12 @@ static void update(struct evm_env* env,
     printf("EVM-C: UPDATE %d\n", key);
 }
 
-static int64_t call(
-    struct evm_env* _opaqueEnv,
-    const struct evm_message* _msg,
-    uint8_t* _outputData,
-    size_t _outputSize
-)
+static void call(struct evm_result* result,
+                 struct evm_env* env,
+                 const struct evm_message* msg)
 {
-    printf("EVM-C: CALL (depth: %d)\n", _msg->depth);
-    return EVM_CALL_FAILURE;
+    printf("EVM-C: CALL (depth: %d)\n", msg->depth);
+    result->code = EVM_FAILURE;
 }
 
 static void get_tx_context(struct evm_tx_context* result, struct evm_env* env)

--- a/examples/examplevm.c
+++ b/examples/examplevm.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <limits.h>
+#include <evm.h>
 #include "evm.h"
 
 
@@ -93,7 +94,7 @@ static struct evm_result execute(struct evm_instance* instance,
         ret.output_data = output_data;
         ret.output_size = address_size;
         ret.release = &free_result_output_data;
-        ret.context = NULL; // We don't need another pointer.
+        ret.payload.pointer = NULL; // We don't need another pointer.
         return ret;
     }
     else if (code_size == strlen(counter) &&

--- a/examples/examplevm.c
+++ b/examples/examplevm.c
@@ -94,7 +94,6 @@ static struct evm_result execute(struct evm_instance* instance,
         ret.output_data = output_data;
         ret.output_size = address_size;
         ret.release = &free_result_output_data;
-        ret.payload.pointer = NULL; // We don't need another pointer.
         return ret;
     }
     else if (code_size == strlen(counter) &&

--- a/examples/examplevm.c
+++ b/examples/examplevm.c
@@ -2,7 +2,6 @@
 #include <string.h>
 #include <limits.h>
 #include <evm.h>
-#include "evm.h"
 
 
 struct examplevm
@@ -43,6 +42,7 @@ int evm_set_option(struct evm_instance* instance,
 
 static void evm_release_result(struct evm_result const* result)
 {
+    (void)result;
 }
 
 static void free_result_output_data(struct evm_result const* result)

--- a/include/evm.h
+++ b/include/evm.h
@@ -121,6 +121,7 @@ typedef void (*evm_release_result_fn)(struct evm_result const* result);
 /// The EVM code execution result.
 struct evm_result {
     /// The execution result code.
+    /// FIXME: Rename to 'status' or 'status_code'.
     enum evm_result_code code;
 
     /// The amount of gas left after the execution.
@@ -305,28 +306,16 @@ typedef void (*evm_update_state_fn)(struct evm_env* env,
                                     const union evm_variant* arg1,
                                     const union evm_variant* arg2);
 
-/// The flag indicating call failure in evm_call_fn() -- highest bit set.
-static const int64_t EVM_CALL_FAILURE = 0x8000000000000000;
-
 /// Pointer to the callback function supporting EVM calls.
 ///
-/// @param env          Pointer to execution environment managed by the host
+/// @param[out] result  Call result.
+/// @param      env     Pointer to execution environment managed by the host
 ///                     application.
-/// @param msg          Call parameters.
-/// @param output       The reference to the memory where the call output is to
-///                     be copied. In case of CREATE, the memory is guaranteed
-///                     to be at least 20 bytes to hold the address of the
-///                     created contract.
-/// @param output_data  The size of the output data. In case of CREATE, expected
-///                     value is 20.
-/// @return      If non-negative - the amount of gas left,
-///              If negative - an exception occurred during the call/create.
-///              There is no need to set 0 address in the output in this case.
-typedef int64_t (*evm_call_fn)(
+/// @param      msg     Call parameters.
+typedef void (*evm_call_fn)(
+    struct evm_result* result,
     struct evm_env* env,
-    const struct evm_message* msg,
-    uint8_t* output,
-    size_t output_size);
+    const struct evm_message* msg);
 
 
 struct evm_instance;  ///< Forward declaration.

--- a/include/evm.h
+++ b/include/evm.h
@@ -170,12 +170,19 @@ struct evm_result {
     /// function to the result itself allows EVM composition.
     evm_release_result_fn release;
 
-    /// Reserved data to be optionally used by implementations.
-    union {
-        uint8_t bytes[24];
-        struct evm_uint160be address;
-        void* pointer;
-    } payload;
+    /// Reserved data that MAY be used by a evm_result object creator.
+    ///
+    /// This reserved 24 bytes extends the size of the evm_result to 64 bytes
+    /// (full cache line).
+    /// An EVM implementation MAY use this memory to keep additional data
+    /// when returning result from ::evm_execute_fn.
+    /// The host application MAY use this memory to keep additional data
+    /// when returning result of performed calls from ::evm_call_fn.
+    union
+    {
+        void* context;     ///< A pointer for storing external objects.
+        uint8_t data[24];  ///< 24 bytes of reserved data.
+    } reserved;
 };
 
 /// The query callback key.

--- a/include/evm.h
+++ b/include/evm.h
@@ -169,12 +169,12 @@ struct evm_result {
     /// function to the result itself allows EVM composition.
     evm_release_result_fn release;
 
-    /// The optional pointer to an internal EVM context.
-    ///
-    /// This field MAY be used by _EVM implementations_ to store additional
-    /// result context (e.g. memory buffers). The pointer value MUST NOT
-    /// be accessed nor changed by EVM users.
-    void* context;
+    /// Reserved data to be optionally used by implementations.
+    union {
+        uint8_t bytes[24];
+        struct evm_uint160be address;
+        void* pointer;
+    } payload;
 };
 
 /// The query callback key.

--- a/libevmjit/Ext.h
+++ b/libevmjit/Ext.h
@@ -11,7 +11,11 @@ namespace eth
 {
 namespace jit
 {
-	class Memory;
+
+/// The flag indicating call failure in evm_call_fn() -- highest bit set.
+constexpr int64_t EVM_CALL_FAILURE = 0x8000000000000000;
+
+class Memory;
 
 struct MemoryRef
 {

--- a/tests/test-evm.cpp
+++ b/tests/test-evm.cpp
@@ -1,6 +1,9 @@
 #include <evm.h>
 
-int64_t test_call_failure_constant(int64_t a)
+evm_result test_call_failure(int64_t gas)
 {
-    return a | EVM_CALL_FAILURE;
+    evm_result result{};
+    result.code = EVM_FAILURE;
+    result.gas_left = gas;
+    return result;
 }


### PR DESCRIPTION
Now EVM-C `call` callback also uses `evm_result` to return from calls.