### PR TITLE
EVM-C: Split state update functions

### DIFF
--- a/examples/capi.c
+++ b/examples/capi.c
@@ -42,13 +42,12 @@ static void query(union evm_variant* result,
     }
 }
 
-static void update(struct evm_env* env,
-                   enum evm_update_key key,
-                   const struct evm_uint160be* addr,
-                   const union evm_variant* arg1,
-                   const union evm_variant* arg2)
+static void set_storage(struct evm_env* env,
+                        const struct evm_uint160be* addr,
+                        const struct evm_uint256be* key,
+                        const struct evm_uint256be* value)
 {
-    printf("EVM-C: UPDATE %d\n", key);
+    printf("EVM-C: SSTORE");
 }
 
 static void call(struct evm_result* result,
@@ -76,7 +75,7 @@ int main(int argc, char *argv[]) {
     if (factory.abi_version != EVM_ABI_VERSION)
         return 1;  // Incompatible ABI version.
 
-    struct evm_instance* jit = factory.create(query, update, NULL, call,
+    struct evm_instance* jit = factory.create(query, set_storage, NULL, call,
                                               get_tx_context, get_block_hash,
                                               NULL);
 

--- a/examples/capi.c
+++ b/examples/capi.c
@@ -76,7 +76,7 @@ int main(int argc, char *argv[]) {
     if (factory.abi_version != EVM_ABI_VERSION)
         return 1;  // Incompatible ABI version.
 
-    struct evm_instance* jit = factory.create(query, update, call,
+    struct evm_instance* jit = factory.create(query, update, NULL, call,
                                               get_tx_context, get_block_hash,
                                               NULL);
 

--- a/examples/capi.c
+++ b/examples/capi.c
@@ -77,7 +77,8 @@ int main(int argc, char *argv[]) {
         return 1;  // Incompatible ABI version.
 
     struct evm_instance* jit = factory.create(query, update, call,
-                                              get_tx_context, get_block_hash);
+                                              get_tx_context, get_block_hash,
+                                              NULL);
 
     uint8_t const code[] = "Place some EVM bytecode here";
     const size_t code_size = sizeof(code);

--- a/examples/examplevm.c
+++ b/examples/examplevm.c
@@ -120,7 +120,8 @@ static struct evm_instance* evm_create(evm_query_state_fn query_fn,
                                        evm_update_state_fn update_fn,
                                        evm_call_fn call_fn,
                                        evm_get_tx_context_fn get_tx_context_fn,
-                                       evm_get_block_hash_fn get_block_hash_fn)
+                                       evm_get_block_hash_fn get_block_hash_fn,
+                                       evm_log_fn log_fn)
 {
     struct examplevm* vm = calloc(1, sizeof(struct examplevm));
     struct evm_instance* interface = &vm->instance;

--- a/examples/examplevm.c
+++ b/examples/examplevm.c
@@ -9,9 +9,11 @@ struct examplevm
     struct evm_instance instance;
     evm_query_state_fn query_fn;
     evm_set_storage_fn set_storage_fn;
+    evm_selfdestruct_fn selfdestruct_fn;
     evm_call_fn call_fn;
     evm_get_tx_context_fn get_tx_context_fn;
     evm_get_block_hash_fn get_block_hash_fn;
+    evm_log_fn log_fn;
 
     int example_option;
 };
@@ -115,7 +117,7 @@ static struct evm_result execute(struct evm_instance* instance,
 }
 
 static struct evm_instance* evm_create(evm_query_state_fn query_fn,
-                                       evm_set_storage_fn update_fn,
+                                       evm_set_storage_fn set_storage_fn,
                                        evm_selfdestruct_fn selfdestruct_fn,
                                        evm_call_fn call_fn,
                                        evm_get_tx_context_fn get_tx_context_fn,
@@ -128,10 +130,12 @@ static struct evm_instance* evm_create(evm_query_state_fn query_fn,
     interface->execute = execute;
     interface->set_option = evm_set_option;
     vm->query_fn = query_fn;
-    vm->set_storage_fn = update_fn;
+    vm->set_storage_fn = set_storage_fn;
+    vm->selfdestruct_fn = selfdestruct_fn;
     vm->call_fn = call_fn;
     vm->get_tx_context_fn = get_tx_context_fn;
     vm->get_block_hash_fn = get_block_hash_fn;
+    vm->log_fn = log_fn;
     return interface;
 }
 

--- a/examples/examplevm.c
+++ b/examples/examplevm.c
@@ -8,7 +8,7 @@ struct examplevm
 {
     struct evm_instance instance;
     evm_query_state_fn query_fn;
-    evm_update_state_fn update_fn;
+    evm_set_storage_fn set_storage_fn;
     evm_call_fn call_fn;
     evm_get_tx_context_fn get_tx_context_fn;
     evm_get_block_hash_fn get_block_hash_fn;
@@ -102,9 +102,7 @@ static struct evm_result execute(struct evm_instance* instance,
         const struct evm_uint256be index = {{0,}};
         vm->query_fn(&value, env, EVM_SLOAD, &msg->address, &index);
         value.uint256be.bytes[31] += 1;
-        union evm_variant arg;
-        arg.uint256be = index;
-        vm->update_fn(env, EVM_SSTORE, &msg->address, &arg, &value);
+        vm->set_storage_fn(env, &msg->address, &index, &value.uint256be);
         ret.code = EVM_SUCCESS;
         return ret;
     }
@@ -117,7 +115,7 @@ static struct evm_result execute(struct evm_instance* instance,
 }
 
 static struct evm_instance* evm_create(evm_query_state_fn query_fn,
-                                       evm_update_state_fn update_fn,
+                                       evm_set_storage_fn update_fn,
                                        evm_selfdestruct_fn selfdestruct_fn,
                                        evm_call_fn call_fn,
                                        evm_get_tx_context_fn get_tx_context_fn,
@@ -130,7 +128,7 @@ static struct evm_instance* evm_create(evm_query_state_fn query_fn,
     interface->execute = execute;
     interface->set_option = evm_set_option;
     vm->query_fn = query_fn;
-    vm->update_fn = update_fn;
+    vm->set_storage_fn = update_fn;
     vm->call_fn = call_fn;
     vm->get_tx_context_fn = get_tx_context_fn;
     vm->get_block_hash_fn = get_block_hash_fn;

--- a/examples/examplevm.c
+++ b/examples/examplevm.c
@@ -118,6 +118,7 @@ static struct evm_result execute(struct evm_instance* instance,
 
 static struct evm_instance* evm_create(evm_query_state_fn query_fn,
                                        evm_update_state_fn update_fn,
+                                       evm_selfdestruct_fn selfdestruct_fn,
                                        evm_call_fn call_fn,
                                        evm_get_tx_context_fn get_tx_context_fn,
                                        evm_get_block_hash_fn get_block_hash_fn,

--- a/include/evm.h
+++ b/include/evm.h
@@ -207,15 +207,6 @@ union evm_variant {
     /// A big-endian 256-bit integer or hash.
     struct evm_uint256be uint256be;
 
-    struct {
-        /// Additional padding to align the evm_variant::address with lower
-        /// bytes of a full 256-bit hash.
-        uint8_t address_padding[12];
-
-        /// An Ethereum address.
-        struct evm_uint160be address;
-    };
-
     /// A memory reference.
     struct {
         /// Pointer to the data.
@@ -250,13 +241,13 @@ union evm_variant {
 ///   @result evm_variant::data       The appropriate code for the given address or NULL if not found.
 ///
 /// - ::EVM_CODE_SIZE
-///   @result evm_variant::data       The appropriate code size for the given address or 0 if not found.
+///   @result evm_variant::int64      The appropriate code size for the given address or 0 if not found.
 ///
 /// - ::EVM_BALANCE
 ///   @result evm_variant::uint256be  The appropriate balance for the given address or 0 if not found.
 ///
 /// - ::EVM_ACCOUNT_EXISTS
-///   @result evm_variant::uint256be  The hash of the requested block or 0 if not found.
+///   @result evm_variant::int64      1 if exists, 0 if not.
 ///
 ///
 /// @todo

--- a/include/evm.h
+++ b/include/evm.h
@@ -273,8 +273,6 @@ typedef void (*evm_query_state_fn)(union evm_variant* result,
 /// The update callback key.
 enum evm_update_key {
     EVM_SSTORE = 0,        ///< Update storage entry
-    EVM_SELFDESTRUCT = 2,  ///< Mark contract as selfdestructed and set
-                           ///  beneficiary address.
 };
 
 
@@ -291,18 +289,23 @@ enum evm_update_key {
 /// - ::EVM_SSTORE
 ///   @param arg1 evm_variant::uint256be  The index of the storage entry.
 ///   @param arg2 evm_variant::uint256be  The value to be stored.
-///
-/// - ::EVM_SELFDESTRUCT
-///   @param arg1 evm_variant::address  The beneficiary address.
-///   @param arg2 n/a
-///
-/// @todo
-/// - Move LOG to separated callback function.
 typedef void (*evm_update_state_fn)(struct evm_env* env,
                                     enum evm_update_key key,
                                     const struct evm_uint160be* address,
                                     const union evm_variant* arg1,
                                     const union evm_variant* arg2);
+
+/// Selfdestruct callback function.
+///
+/// This callback function is used by an EVM to SELFDESTRUCT given contract.
+/// @param env          The pointer to the execution environment managed by
+///                     the host application.
+/// @param address      The address of the contract to be selfdestructed.
+/// @param beneficiary  The address where the remaining ETH is going to be
+///                     transfer.
+typedef void (*evm_selfdestruct_fn)(struct evm_env* env,
+                                    const struct evm_uint160be* address,
+                                    const struct evm_uint160be* beneficiary);
 
 /// Log callback function.
 ///
@@ -349,6 +352,7 @@ struct evm_instance;  ///< Forward declaration.
 /// @return           Pointer to the created EVM instance.
 typedef struct evm_instance* (*evm_create_fn)(evm_query_state_fn query_fn,
                                               evm_update_state_fn update_fn,
+                                              evm_selfdestruct_fn selfdestruct_fn,
                                               evm_call_fn call_fn,
                                               evm_get_tx_context_fn get_tx_context_fn,
                                               evm_get_block_hash_fn get_block_hash_fn,

--- a/include/evm.h
+++ b/include/evm.h
@@ -273,7 +273,6 @@ typedef void (*evm_query_state_fn)(union evm_variant* result,
 /// The update callback key.
 enum evm_update_key {
     EVM_SSTORE = 0,        ///< Update storage entry
-    EVM_LOG = 1,           ///< Log.
     EVM_SELFDESTRUCT = 2,  ///< Mark contract as selfdestructed and set
                            ///  beneficiary address.
 };
@@ -293,14 +292,6 @@ enum evm_update_key {
 ///   @param arg1 evm_variant::uint256be  The index of the storage entry.
 ///   @param arg2 evm_variant::uint256be  The value to be stored.
 ///
-/// - ::EVM_LOG
-///   @param arg1 evm_variant::data  The log unindexed data.
-///   @param arg2 evm_variant::data  The log topics. The referenced data is an
-///                                  array of evm_uint256be[] of possible length
-///                                  from 0 to 4. So the valid
-///                                  evm_variant::data_size values are 0, 32, 64
-///                                  92 and 128.
-///
 /// - ::EVM_SELFDESTRUCT
 ///   @param arg1 evm_variant::address  The beneficiary address.
 ///   @param arg2 n/a
@@ -312,6 +303,24 @@ typedef void (*evm_update_state_fn)(struct evm_env* env,
                                     const struct evm_uint160be* address,
                                     const union evm_variant* arg1,
                                     const union evm_variant* arg2);
+
+/// Log callback function.
+///
+/// This callback function is used by an EVM to inform about a LOG that happened
+/// during an EVM bytecode execution.
+/// @param env         The pointer to execution environment managed by the host
+///                    application.
+/// @param address     The address of the contract that generated the log.
+/// @param data        The pointer to unindexed data attached to the log.
+/// @param data_size   The length of the data.
+/// @param topics      The pointer to the array of topics attached to the log.
+/// @param topics_num  The number of the topics. Valid values 0 - 4.
+typedef void (*evm_log_fn)(struct evm_env* env,
+                           const struct evm_uint160be* address,
+                           const uint8_t* data,
+                           size_t data_size,
+                           struct evm_uint256be topics[],
+                           size_t topics_num);
 
 /// Pointer to the callback function supporting EVM calls.
 ///
@@ -342,7 +351,8 @@ typedef struct evm_instance* (*evm_create_fn)(evm_query_state_fn query_fn,
                                               evm_update_state_fn update_fn,
                                               evm_call_fn call_fn,
                                               evm_get_tx_context_fn get_tx_context_fn,
-                                              evm_get_block_hash_fn get_block_hash_fn);
+                                              evm_get_block_hash_fn get_block_hash_fn,
+                                              evm_log_fn log_fn);
 
 /// Destroys the EVM instance.
 ///

--- a/include/evm.h
+++ b/include/evm.h
@@ -282,7 +282,7 @@ typedef void (*evm_set_storage_fn)(struct evm_env* env,
 ///                     the host application.
 /// @param address      The address of the contract to be selfdestructed.
 /// @param beneficiary  The address where the remaining ETH is going to be
-///                     transfer.
+///                     transferred.
 typedef void (*evm_selfdestruct_fn)(struct evm_env* env,
                                     const struct evm_uint160be* address,
                                     const struct evm_uint160be* beneficiary);
@@ -291,19 +291,20 @@ typedef void (*evm_selfdestruct_fn)(struct evm_env* env,
 ///
 /// This callback function is used by an EVM to inform about a LOG that happened
 /// during an EVM bytecode execution.
-/// @param env         The pointer to execution environment managed by the host
-///                    application.
-/// @param address     The address of the contract that generated the log.
-/// @param data        The pointer to unindexed data attached to the log.
-/// @param data_size   The length of the data.
-/// @param topics      The pointer to the array of topics attached to the log.
-/// @param topics_num  The number of the topics. Valid values 0 - 4.
+/// @param env           The pointer to execution environment managed by
+///                      the host application.
+/// @param address       The address of the contract that generated the log.
+/// @param data          The pointer to unindexed data attached to the log.
+/// @param data_size     The length of the data.
+/// @param topics        The pointer to the array of topics attached to the log.
+/// @param topics_count  The number of the topics. Valid values are between
+///                      0 and 4 inclusively.
 typedef void (*evm_log_fn)(struct evm_env* env,
                            const struct evm_uint160be* address,
                            const uint8_t* data,
                            size_t data_size,
-                           struct evm_uint256be topics[],
-                           size_t topics_num);
+                           const struct evm_uint256be topics[],
+                           size_t topics_count);
 
 /// Pointer to the callback function supporting EVM calls.
 ///
@@ -331,7 +332,7 @@ struct evm_instance;  ///< Forward declaration.
 /// @param get_block_hash_fn  Pointer to get block hash function. Nonnull.
 /// @return           Pointer to the created EVM instance.
 typedef struct evm_instance* (*evm_create_fn)(evm_query_state_fn query_fn,
-                                              evm_set_storage_fn update_fn,
+                                              evm_set_storage_fn set_storage_fn,
                                               evm_selfdestruct_fn selfdestruct_fn,
                                               evm_call_fn call_fn,
                                               evm_get_tx_context_fn get_tx_context_fn,

--- a/include/evm.h
+++ b/include/evm.h
@@ -270,30 +270,19 @@ typedef void (*evm_query_state_fn)(union evm_variant* result,
                                    const struct evm_uint160be* address,
                                    const struct evm_uint256be* storage_key);
 
-/// The update callback key.
-enum evm_update_key {
-    EVM_SSTORE = 0,        ///< Update storage entry
-};
-
-
-/// Update callback function.
+/// Set storage callback function.
 ///
-/// This callback function is used by the EVM to modify contract state in the
-/// host application.
-/// @param env  Pointer to execution environment managed by the host
-///             application.
-/// @param key  The kind of the update. See evm_update_key and details below.
-///
-/// ## Kinds of updates
-///
-/// - ::EVM_SSTORE
-///   @param arg1 evm_variant::uint256be  The index of the storage entry.
-///   @param arg2 evm_variant::uint256be  The value to be stored.
-typedef void (*evm_update_state_fn)(struct evm_env* env,
-                                    enum evm_update_key key,
-                                    const struct evm_uint160be* address,
-                                    const union evm_variant* arg1,
-                                    const union evm_variant* arg2);
+/// This callback function is used by an EVM to update the given contract
+/// storage entry
+/// @param env      Pointer to execution environment managed by the host
+///                 application.
+/// @param address  The address of the contract.
+/// @param key      The index of the storage entry.
+/// @param value    The value to be stored.
+typedef void (*evm_set_storage_fn)(struct evm_env* env,
+                                   const struct evm_uint160be* address,
+                                   const struct evm_uint256be* key,
+                                   const struct evm_uint256be* value);
 
 /// Selfdestruct callback function.
 ///
@@ -351,7 +340,7 @@ struct evm_instance;  ///< Forward declaration.
 /// @param get_block_hash_fn  Pointer to get block hash function. Nonnull.
 /// @return           Pointer to the created EVM instance.
 typedef struct evm_instance* (*evm_create_fn)(evm_query_state_fn query_fn,
-                                              evm_update_state_fn update_fn,
+                                              evm_set_storage_fn update_fn,
                                               evm_selfdestruct_fn selfdestruct_fn,
                                               evm_call_fn call_fn,
                                               evm_get_tx_context_fn get_tx_context_fn,

--- a/libevmjit/Ext.cpp
+++ b/libevmjit/Ext.cpp
@@ -103,6 +103,25 @@ llvm::Function* getUpdateFunc(llvm::Module* _module)
 	return func;
 }
 
+llvm::Function* getLogFunc(llvm::Module* _module)
+{
+	static const auto funcName = "evm.log";
+	auto func = _module->getFunction(funcName);
+	if (!func)
+	{
+		auto addrPtrTy = llvm::Type::getIntNPtrTy(_module->getContext(), 160);
+		auto fty = llvm::FunctionType::get(Type::Void, {Type::EnvPtr, addrPtrTy, Type::BytePtr, Type::Size, Type::WordPtr, Type::Size}, false);
+		func = llvm::Function::Create(fty, llvm::Function::ExternalLinkage, funcName, _module);
+		func->addAttribute(3, llvm::Attribute::ReadOnly);
+		func->addAttribute(3, llvm::Attribute::NoAlias);
+		func->addAttribute(3, llvm::Attribute::NoCapture);
+		func->addAttribute(5, llvm::Attribute::ReadOnly);
+		func->addAttribute(5, llvm::Attribute::NoAlias);
+		func->addAttribute(5, llvm::Attribute::NoCapture);
+	}
+	return func;
+}
+
 llvm::StructType* getMemRefTy(llvm::Module* _module)
 {
 	static const auto name = "evm.memref";
@@ -432,8 +451,8 @@ void Ext::log(llvm::Value* _memIdx, llvm::Value* _numBytes, llvm::ArrayRef<llvm:
 		m_topics = m_builder.CreateAlloca(Type::Word, m_builder.getInt32(4), "topics");
 	}
 
-	auto begin = m_memoryMan.getBytePtr(_memIdx);
-	auto size = m_builder.CreateTrunc(_numBytes, Type::Size, "size");
+	auto dataPtr = m_memoryMan.getBytePtr(_memIdx);
+	auto dataSize = m_builder.CreateTrunc(_numBytes, Type::Size, "data.size");
 
 	for (size_t i = 0; i < _topics.size(); ++i)
 	{
@@ -441,26 +460,15 @@ void Ext::log(llvm::Value* _memIdx, llvm::Value* _numBytes, llvm::ArrayRef<llvm:
 		auto p = m_builder.CreateConstGEP1_32(m_topics, static_cast<unsigned>(i));
 		m_builder.CreateStore(t, p);
 	}
+	auto numTopics = m_builder.getInt64(_topics.size());
 
 	auto addrTy = m_builder.getIntNTy(160);
-	auto func = getUpdateFunc(getModule());
-	auto a = getArgAlloca();
-	auto memRefTy = getMemRefTy(getModule());
-	auto pMemRef = m_builder.CreateBitCast(a, memRefTy->getPointerTo());
-	auto pData = m_builder.CreateConstGEP2_32(memRefTy, pMemRef, 0, 0, "log.data");
-	m_builder.CreateStore(begin, pData);
-	auto pSize = m_builder.CreateConstGEP2_32(memRefTy, pMemRef, 0, 1, "log.size");
-	m_builder.CreateStore(size, pSize);
-
-	auto b = getArgAlloca();
-	pMemRef = m_builder.CreateBitCast(b, memRefTy->getPointerTo());
-	pData = m_builder.CreateConstGEP2_32(memRefTy, pMemRef, 0, 0, "topics.data");
-	m_builder.CreateStore(m_builder.CreateBitCast(m_topics, m_builder.getInt8PtrTy()), pData);
-	pSize = m_builder.CreateConstGEP2_32(memRefTy, pMemRef, 0, 1, "topics.size");
-	m_builder.CreateStore(m_builder.getInt64(_topics.size() * 32), pSize);
-
+	auto func = getLogFunc(getModule());
+	
 	auto myAddr = Endianness::toBE(m_builder, m_builder.CreateTrunc(Endianness::toNative(m_builder, getRuntimeManager().getAddress()), addrTy));
-	createCABICall(func, {getRuntimeManager().getEnvPtr(), m_builder.getInt32(EVM_LOG), myAddr, a, b});
+	createCABICall(func, {
+		getRuntimeManager().getEnvPtr(), myAddr, dataPtr, dataSize, m_topics, numTopics
+	});
 }
 
 llvm::Value* Ext::call(evm_call_kind _kind,

--- a/libevmjit/JIT.cpp
+++ b/libevmjit/JIT.cpp
@@ -142,6 +142,7 @@ public:
 
 	evm_query_state_fn queryFn = nullptr;
 	evm_update_state_fn updateFn = nullptr;
+	evm_selfdestruct_fn selfdestructFn = nullptr;
 	evm_call_fn callFn = nullptr;
 	evm_get_tx_context_fn getTxContextFn = nullptr;
 	evm_get_block_hash_fn getBlockHashFn = nullptr;
@@ -199,6 +200,7 @@ class SymbolResolver : public llvm::SectionMemoryManager
 			.Case("env_sha3", reinterpret_cast<uint64_t>(&keccak))
 			.Case("evm.query", reinterpret_cast<uint64_t>(jit.queryFn))
 			.Case("evm.update", reinterpret_cast<uint64_t>(jit.updateFn))
+			.Case("evm.selfdestruct", reinterpret_cast<uint64_t>(jit.selfdestructFn))
 			.Case("evm.call", reinterpret_cast<uint64_t>(call_v2))
 			.Case("evm.get_tx_context", reinterpret_cast<uint64_t>(jit.getTxContextFn))
 			.Case("evm.blockhash", reinterpret_cast<uint64_t>(jit.getBlockHashFn))
@@ -321,7 +323,9 @@ bytes_ref ExecutionContext::getReturnData() const
 extern "C"
 {
 
-static evm_instance* create(evm_query_state_fn queryFn, evm_update_state_fn updateFn,
+static evm_instance* create(
+	evm_query_state_fn queryFn, evm_update_state_fn updateFn,
+	evm_selfdestruct_fn selfdestructFn,
 	evm_call_fn callFn, evm_get_tx_context_fn getTxContextFn,
 	evm_get_block_hash_fn getBlockHashFn, evm_log_fn logFn)
 {
@@ -330,6 +334,7 @@ static evm_instance* create(evm_query_state_fn queryFn, evm_update_state_fn upda
 	auto& jit = JITImpl::instance();
 	jit.queryFn = queryFn;
 	jit.updateFn = updateFn;
+	jit.selfdestructFn = selfdestructFn;
 	jit.callFn = callFn;
 	jit.getTxContextFn = getTxContextFn;
 	jit.getBlockHashFn = getBlockHashFn;

--- a/libevmjit/JIT.cpp
+++ b/libevmjit/JIT.cpp
@@ -31,7 +31,6 @@ static_assert(offsetof(evm_message, code_hash) % 8 == 0, "evm_message.code_hash 
 // Check enums match int size.
 // On GCC/clang the underlying type should be unsigned int, on MSVC int
 static_assert(sizeof(evm_query_key)  == sizeof(int), "Enum `evm_query_key` is not the size of int");
-static_assert(sizeof(evm_update_key) == sizeof(int), "Enum `evm_update_key` is not the size of int");
 static_assert(sizeof(evm_call_kind)  == sizeof(int), "Enum `evm_call_kind` is not the size of int");
 static_assert(sizeof(evm_mode)       == sizeof(int), "Enum `evm_mode` is not the size of int");
 
@@ -141,7 +140,7 @@ public:
 	ExecFunc compile(evm_mode _mode, byte const* _code, uint64_t _codeSize, std::string const& _codeIdentifier);
 
 	evm_query_state_fn queryFn = nullptr;
-	evm_update_state_fn updateFn = nullptr;
+	evm_set_storage_fn updateFn = nullptr;
 	evm_selfdestruct_fn selfdestructFn = nullptr;
 	evm_call_fn callFn = nullptr;
 	evm_get_tx_context_fn getTxContextFn = nullptr;
@@ -199,7 +198,7 @@ class SymbolResolver : public llvm::SectionMemoryManager
 		auto addr = llvm::StringSwitch<uint64_t>(_name)
 			.Case("env_sha3", reinterpret_cast<uint64_t>(&keccak))
 			.Case("evm.query", reinterpret_cast<uint64_t>(jit.queryFn))
-			.Case("evm.update", reinterpret_cast<uint64_t>(jit.updateFn))
+			.Case("evm.sstore", reinterpret_cast<uint64_t>(jit.updateFn))
 			.Case("evm.selfdestruct", reinterpret_cast<uint64_t>(jit.selfdestructFn))
 			.Case("evm.call", reinterpret_cast<uint64_t>(call_v2))
 			.Case("evm.get_tx_context", reinterpret_cast<uint64_t>(jit.getTxContextFn))
@@ -324,7 +323,7 @@ extern "C"
 {
 
 static evm_instance* create(
-	evm_query_state_fn queryFn, evm_update_state_fn updateFn,
+	evm_query_state_fn queryFn, evm_set_storage_fn updateFn,
 	evm_selfdestruct_fn selfdestructFn,
 	evm_call_fn callFn, evm_get_tx_context_fn getTxContextFn,
 	evm_get_block_hash_fn getBlockHashFn, evm_log_fn logFn)

--- a/libevmjit/JIT.cpp
+++ b/libevmjit/JIT.cpp
@@ -145,6 +145,7 @@ public:
 	evm_call_fn callFn = nullptr;
 	evm_get_tx_context_fn getTxContextFn = nullptr;
 	evm_get_block_hash_fn getBlockHashFn = nullptr;
+	evm_log_fn logFn = nullptr;
 
 	evm_message const* currentMsg = nullptr;
 };
@@ -201,6 +202,7 @@ class SymbolResolver : public llvm::SectionMemoryManager
 			.Case("evm.call", reinterpret_cast<uint64_t>(call_v2))
 			.Case("evm.get_tx_context", reinterpret_cast<uint64_t>(jit.getTxContextFn))
 			.Case("evm.blockhash", reinterpret_cast<uint64_t>(jit.getBlockHashFn))
+			.Case("evm.log", reinterpret_cast<uint64_t>(jit.logFn))
 			.Default(0);
 		if (addr)
 			return {addr, llvm::JITSymbolFlags::Exported};
@@ -321,7 +323,7 @@ extern "C"
 
 static evm_instance* create(evm_query_state_fn queryFn, evm_update_state_fn updateFn,
 	evm_call_fn callFn, evm_get_tx_context_fn getTxContextFn,
-	evm_get_block_hash_fn getBlockHashFn)
+	evm_get_block_hash_fn getBlockHashFn, evm_log_fn logFn)
 {
 	// Let's always return the same instance. It's a bit of faking, but actually
 	// this might be a compliant implementation.
@@ -331,6 +333,7 @@ static evm_instance* create(evm_query_state_fn queryFn, evm_update_state_fn upda
 	jit.callFn = callFn;
 	jit.getTxContextFn = getTxContextFn;
 	jit.getBlockHashFn = getBlockHashFn;
+	jit.logFn = logFn;
 	return &jit;
 }
 


### PR DESCRIPTION
cpp-ethereum: https://github.com/ethereum/cpp-ethereum/pull/4117.

This change splits state update combo callback function into 3 functions. The old combo callback was used to handle SSTORE, SELFDESTRUCT and LOG. Now each opcode is handled independently. This means more callback functions to implement, but they are short and simple. And no additional switch needed.

The EVMJIT part is a bit more painful, because declaring a function in LLVM is not so nice as in C.