### PR TITLE
EVM-C: Limit functionality of output in message

### DIFF
--- a/include/evm.h
+++ b/include/evm.h
@@ -131,21 +131,14 @@ struct evm_result {
 
     /// The amount of gas left after the execution.
     ///
-    /// The value is valid only if evm_result::code is ::EVM_SUCCESS
-    /// or ::EVM_REVERT. In other cases all provided gas is assumed to have been
-    /// used.
+    /// If evm_result::code is not ::EVM_SUCCESS nor ::EVM_REVERT
+    /// the value MUST be 0.
     int64_t gas_left;
 
     /// The reference to output data.
     ///
     /// The output contains data coming from RETURN opcode (iff evm_result::code
-    /// field is ::EVM_SUCCESS) or from REVERT opcode (iff evm_result::code
-    /// field is ::EVM_REVERT).
-    ///
-    /// In case the evm_result::code field signals
-    /// a failure the output MAY contain optional explanation of the failure
-    /// for debugging or tracing purposes. In case the explanation is provided
-    /// and contains human-readable text then UTF-8 encoding SHOULD be used.
+    /// field is ::EVM_SUCCESS) or from REVERT opcode.
     ///
     /// The memory containing the output data is owned by EVM and has to be
     /// freed with evm_result::release().

--- a/libevmjit/JIT.cpp
+++ b/libevmjit/JIT.cpp
@@ -185,14 +185,11 @@ static int64_t call_v2(
 	jit.host->call(&result, _opaqueEnv, &msg);
 	// FIXME: Clarify when gas_left is valid.
 	int64_t r = result.gas_left;
-	if (result.code == EVM_SUCCESS || result.code == EVM_REVERT)
-	{
-		auto size = std::min(_outputSize, result.output_size);
-		std::copy(result.output_data, result.output_data + size, _outputData);
-		jit.returnBuffer = {result.output_data, result.output_data + result.output_size};
-	}
-	else
-		jit.returnBuffer.clear();
+
+	// Handle output. It can contain data from RETURN or REVERT opcodes.
+	auto size = std::min(_outputSize, result.output_size);
+	std::copy(result.output_data, result.output_data + size, _outputData);
+	jit.returnBuffer = {result.output_data, result.output_data + result.output_size};
 
 	*o_bufData = jit.returnBuffer.data();
 	*o_bufSize = jit.returnBuffer.size();


### PR DESCRIPTION
Do not allow passing debug and error messages in message.output. We should keep the output buffer for passing consensus-critical data only. We still need to design tracing / debugging subsystem for EVM-C. The place of error messages is there.