### PR TITLE
EVM-C: Remove factory class

### DIFF
--- a/examples/capi.c
+++ b/examples/capi.c
@@ -5,19 +5,19 @@
 
 
 struct evm_uint256be balance(struct evm_context* context,
-                             const struct evm_uint160be* address)
+                             const struct evm_address* address)
 {
     struct evm_uint256be ret = {.bytes = {1, 2, 3, 4}};
     return ret;
 }
 
-struct evm_uint160be address(struct evm_context* context)
+struct evm_address address(struct evm_context* context)
 {
-    struct evm_uint160be ret = {.bytes = {1, 2, 3, 4}};
+    struct evm_address ret = {.bytes = {1, 2, 3, 4}};
     return ret;
 }
 
-static void print_address(const struct evm_uint160be* address)
+static void print_address(const struct evm_address* address)
 {
     int i = 0;
     for (i = 0; i < sizeof(address->bytes); ++i)
@@ -25,7 +25,7 @@ static void print_address(const struct evm_uint160be* address)
 }
 
 static int account_exists(struct evm_context* context,
-                           const struct evm_uint160be* address) {
+                           const struct evm_address* address) {
     printf("EVM-C: EXISTS @");
     print_address(address);
     printf("\n");
@@ -34,7 +34,7 @@ static int account_exists(struct evm_context* context,
 
 static void get_storage(struct evm_uint256be* result,
                         struct evm_context* context,
-                        const struct evm_uint160be* address,
+                        const struct evm_address* address,
                         const struct evm_uint256be* key)
 {
     printf("EVM-C: SLOAD @");
@@ -43,7 +43,7 @@ static void get_storage(struct evm_uint256be* result,
 }
 
 static void set_storage(struct evm_context* context,
-                        const struct evm_uint160be* address,
+                        const struct evm_address* address,
                         const struct evm_uint256be* key,
                         const struct evm_uint256be* value)
 {
@@ -54,7 +54,7 @@ static void set_storage(struct evm_context* context,
 
 static void get_balance(struct evm_uint256be* result,
                         struct evm_context* context,
-                        const struct evm_uint160be* address)
+                        const struct evm_address* address)
 {
     printf("EVM-C: BALANCE @");
     print_address(address);
@@ -64,7 +64,7 @@ static void get_balance(struct evm_uint256be* result,
 
 static size_t get_code(const uint8_t** code,
                        struct evm_context* context,
-                       const struct evm_uint160be* address)
+                       const struct evm_address* address)
 {
     printf("EVM-C: CODE @");
     print_address(address);
@@ -73,8 +73,8 @@ static size_t get_code(const uint8_t** code,
 }
 
 static void selfdestruct(struct evm_context* context,
-                         const struct evm_uint160be* address,
-                         const struct evm_uint160be* beneficiary)
+                         const struct evm_address* address,
+                         const struct evm_address* beneficiary)
 {
     printf("EVM-C: SELFDESTRUCT ");
     print_address(address);
@@ -105,7 +105,7 @@ static void get_block_hash(struct evm_uint256be* result, struct evm_context* con
 /// EVM log callback.
 ///
 /// @note The `evm_log` name is used to avoid conflict with `log()` C function.
-static void evm_log(struct evm_context* context, const struct evm_uint160be* address,
+static void evm_log(struct evm_context* context, const struct evm_address* address,
                     const uint8_t* data, size_t data_size,
                     const struct evm_uint256be topics[], size_t topics_count)
 {
@@ -136,7 +136,7 @@ int main(int argc, char *argv[]) {
     struct evm_uint256be code_hash = {.bytes = {1, 2, 3,}};
     uint8_t const input[] = "Hello World!";
     struct evm_uint256be value = {{1, 0,}};
-    struct evm_uint160be addr = {{0, 1, 2,}};
+    struct evm_address addr = {{0, 1, 2,}};
     int64_t gas = 200000;
 
     struct evm_context ctx = {&ctx_fn_table};

--- a/examples/capi.c
+++ b/examples/capi.c
@@ -88,7 +88,7 @@ static void call(struct evm_result* result,
                  const struct evm_message* msg)
 {
     printf("EVM-C: CALL (depth: %d)\n", msg->depth);
-    result->code = EVM_FAILURE;
+    result->status_code = EVM_FAILURE;
 }
 
 static void get_tx_context(struct evm_tx_context* result, struct evm_context* context)
@@ -148,8 +148,8 @@ int main(int argc, char *argv[]) {
         jit->execute(jit, &ctx, EVM_HOMESTEAD, &msg, code, code_size);
 
     printf("Execution result:\n");
-    if (result.code != EVM_SUCCESS) {
-      printf("  EVM execution failure: %d\n", result.code);
+    if (result.status_code != EVM_SUCCESS) {
+      printf("  EVM execution failure: %d\n", result.status_code);
     } else {
         printf("  Gas used: %ld\n", gas - result.gas_left);
         printf("  Gas left: %ld\n", result.gas_left);

--- a/examples/capi.c
+++ b/examples/capi.c
@@ -127,9 +127,7 @@ static const struct evm_host example_host = {
 
 /// Example how the API is supposed to be used.
 int main(int argc, char *argv[]) {
-    struct evm_factory factory = examplevm_get_factory();
-
-    struct evm_instance* jit = factory.create();
+    struct evm_instance* jit = examplevm_create();
     if (jit->abi_version != EVM_ABI_VERSION)
         return 1;  // Incompatible ABI version.
 

--- a/examples/capi.c
+++ b/examples/capi.c
@@ -112,7 +112,7 @@ static void evm_log(struct evm_context* context, const struct evm_uint160be* add
     printf("EVM-C: LOG%d\n", (int)topics_count);
 }
 
-static const struct evm_host example_host = {
+static const struct evm_context_fn_table ctx_fn_table = {
     account_exists,
     get_storage,
     set_storage,
@@ -139,11 +139,13 @@ int main(int argc, char *argv[]) {
     struct evm_uint160be addr = {{0, 1, 2,}};
     int64_t gas = 200000;
 
+    struct evm_context ctx = {&ctx_fn_table};
+
     struct evm_message msg = {addr, addr, value, input, sizeof(input),
                               code_hash, gas, 0};
 
     struct evm_result result =
-        jit->execute(jit, NULL, EVM_HOMESTEAD, &msg, code, code_size);
+        jit->execute(jit, &ctx, EVM_HOMESTEAD, &msg, code, code_size);
 
     printf("Execution result:\n");
     if (result.code != EVM_SUCCESS) {

--- a/examples/capi.c
+++ b/examples/capi.c
@@ -128,10 +128,10 @@ static const struct evm_host example_host = {
 /// Example how the API is supposed to be used.
 int main(int argc, char *argv[]) {
     struct evm_factory factory = examplevm_get_factory();
-    if (factory.abi_version != EVM_ABI_VERSION)
-        return 1;  // Incompatible ABI version.
 
-    struct evm_instance* jit = factory.create(&example_host);
+    struct evm_instance* jit = factory.create();
+    if (jit->abi_version != EVM_ABI_VERSION)
+        return 1;  // Incompatible ABI version.
 
     uint8_t const code[] = "Place some EVM bytecode here";
     const size_t code_size = sizeof(code);

--- a/examples/examplevm.c
+++ b/examples/examplevm.c
@@ -1,15 +1,15 @@
+#include <evm.h>
+
+#include <limits.h>
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <limits.h>
-#include <evm.h>
 
 
 struct examplevm
 {
     struct evm_instance instance;
-    const struct evm_host* host;
-
-    int example_option;
+    int verbose;
 };
 
 static void evm_destroy(struct evm_instance* evm)
@@ -25,11 +25,11 @@ int evm_set_option(struct evm_instance* instance,
                    char const* value)
 {
     struct examplevm* vm = (struct examplevm*)instance;
-    if (strcmp(name, "example-option") == 0) {
+    if (strcmp(name, "verbose") == 0) {
         long int v = strtol(value, NULL, 0);
         if (v > INT_MAX || v < INT_MIN)
             return 0;
-        vm->example_option = (int)v;
+        vm->verbose = (int)v;
         return 1;
     }
 
@@ -77,7 +77,7 @@ static struct evm_result execute(struct evm_instance* instance,
     const char counter[] = "600160005401600055";
 
     if (code_size == strlen(return_address) &&
-        strncmp((const char*)code, return_address, code_size)) {
+        strncmp((const char*)code, return_address, code_size) == 0) {
         static const size_t address_size = sizeof(msg->address);
         uint8_t* output_data = (uint8_t*)malloc(address_size);
         if (!output_data) {
@@ -93,12 +93,12 @@ static struct evm_result execute(struct evm_instance* instance,
         return ret;
     }
     else if (code_size == strlen(counter) &&
-        strncmp((const char*)code, counter, code_size)) {
+        strncmp((const char*)code, counter, code_size) == 0) {
         struct evm_uint256be value;
         const struct evm_uint256be index = {{0,}};
-        vm->host->get_storage(&value, context, &msg->address, &index);
+        context->fn_table->get_storage(&value, context, &msg->address, &index);
         value.bytes[31] += 1;
-        vm->host->set_storage(context, &msg->address, &index, &value);
+        context->fn_table->set_storage(context, &msg->address, &index, &value);
         ret.code = EVM_SUCCESS;
         return ret;
     }
@@ -106,6 +106,9 @@ static struct evm_result execute(struct evm_instance* instance,
     ret.release = evm_release_result;
     ret.code = EVM_FAILURE;
     ret.gas_left = 0;
+
+    if (vm->verbose)
+        printf("Execution done.\n");
 
     return ret;
 }

--- a/examples/examplevm.c
+++ b/examples/examplevm.c
@@ -112,17 +112,21 @@ static struct evm_result execute(struct evm_instance* instance,
 
 static struct evm_instance* evm_create(const struct evm_host* host)
 {
+    struct evm_instance init = {
+        .abi_version = EVM_ABI_VERSION,
+        .destroy = evm_destroy,
+        .execute = execute,
+        .set_option = evm_set_option
+    };
     struct examplevm* vm = calloc(1, sizeof(struct examplevm));
     struct evm_instance* interface = &vm->instance;
-    interface->destroy = evm_destroy;
-    interface->execute = execute;
-    interface->set_option = evm_set_option;
+    memcpy(interface, &init, sizeof(init));
     vm->host = host;
     return interface;
 }
 
 struct evm_factory examplevm_get_factory()
 {
-    struct evm_factory factory = {EVM_ABI_VERSION, evm_create};
+    struct evm_factory factory = {evm_create};
     return factory;
 }

--- a/examples/examplevm.c
+++ b/examples/examplevm.c
@@ -110,7 +110,7 @@ static struct evm_result execute(struct evm_instance* instance,
     return ret;
 }
 
-static struct evm_instance* evm_create(const struct evm_host* host)
+struct evm_instance* examplevm_create()
 {
     struct evm_instance init = {
         .abi_version = EVM_ABI_VERSION,
@@ -121,12 +121,5 @@ static struct evm_instance* evm_create(const struct evm_host* host)
     struct examplevm* vm = calloc(1, sizeof(struct examplevm));
     struct evm_instance* interface = &vm->instance;
     memcpy(interface, &init, sizeof(init));
-    vm->host = host;
     return interface;
-}
-
-struct evm_factory examplevm_get_factory()
-{
-    struct evm_factory factory = {evm_create};
-    return factory;
 }

--- a/examples/examplevm.c
+++ b/examples/examplevm.c
@@ -60,7 +60,7 @@ static struct evm_result execute(struct evm_instance* instance,
                             "Welcome to Byzantium!" : "Hello Ethereum!";
         ret.output_data = (const uint8_t*)error;
         ret.output_size = strlen(error);
-        ret.code = EVM_FAILURE;
+        ret.status_code = EVM_FAILURE;
         ret.release = NULL;  // We don't need to release the constant messages.
         return ret;
     }
@@ -82,11 +82,11 @@ static struct evm_result execute(struct evm_instance* instance,
         uint8_t* output_data = (uint8_t*)malloc(address_size);
         if (!output_data) {
             // malloc failed, report internal error.
-            ret.code = EVM_INTERNAL_ERROR;
+            ret.status_code = EVM_INTERNAL_ERROR;
             return ret;
         }
         memcpy(output_data, &msg->address, address_size);
-        ret.code = EVM_SUCCESS;
+        ret.status_code = EVM_SUCCESS;
         ret.output_data = output_data;
         ret.output_size = address_size;
         ret.release = &free_result_output_data;
@@ -99,12 +99,12 @@ static struct evm_result execute(struct evm_instance* instance,
         context->fn_table->get_storage(&value, context, &msg->address, &index);
         value.bytes[31] += 1;
         context->fn_table->set_storage(context, &msg->address, &index, &value);
-        ret.code = EVM_SUCCESS;
+        ret.status_code = EVM_SUCCESS;
         return ret;
     }
 
     ret.release = evm_release_result;
-    ret.code = EVM_FAILURE;
+    ret.status_code = EVM_FAILURE;
     ret.gas_left = 0;
 
     if (vm->verbose)

--- a/include/evm.h
+++ b/include/evm.h
@@ -466,8 +466,7 @@ struct evm_instance {
 /// Each EVM implementation MUST provide a function returning an EVM instance.
 /// The function SHOULD be named `<vm-name>_create(void)`.
 ///
-/// @return  EVM instance.
-/// @todo Specify if this function can return null pointer to indicate error.
+/// @return  EVM instance or NULL indicating instance creation failure.
 struct evm_instance* examplevm_create(void);
 
 

--- a/include/evm.h
+++ b/include/evm.h
@@ -332,14 +332,6 @@ struct evm_context {
 
 struct evm_instance;  ///< Forward declaration.
 
-/// Creates the EVM instance.
-///
-/// Creates and initializes an EVM instance by providing the information
-/// about runtime callback functions.
-///
-/// @return      Pointer to the created EVM instance.
-typedef struct evm_instance* (*evm_create_fn)();
-
 /// Destroys the EVM instance.
 ///
 /// @param evm  The EVM instance to be destroyed.
@@ -466,25 +458,17 @@ struct evm_instance {
     evm_set_option_fn set_option;
 };
 
-/// The EVM instance factory.
-///
-/// Provides ABI protection and method to create an EVM instance.
-struct evm_factory {
-
-    /// Pointer to function creating and initializing the EVM instance.
-    evm_create_fn create;
-};
-
 // END Python CFFI declarations
 
-/// Example of a function creating uninitialized instance of an example VM.
+/// Example of a function creating an instance of an example EVM implementation.
 ///
-/// Each EVM implementation is obligated to provided a function returning
-/// an EVM instance.
-/// The function has to be named as `<vm-name>_get_factory(void)`.
+/// Each EVM implementation MUST provide a function returning an EVM instance.
+/// The function SHOULD be named `<vm-name>_create(void)`.
 ///
 /// @return  EVM instance.
-struct evm_factory examplevm_get_factory(void);
+/// @todo Specify if this function can return null pointer to indicate error.
+/// @todo Can we return const pointer?
+struct evm_instance* examplevm_create(void);
 
 
 #if __cplusplus

--- a/include/evm.h
+++ b/include/evm.h
@@ -98,8 +98,8 @@ typedef void (*evm_get_block_hash_fn)(struct evm_uint256be* result,
                                       struct evm_context* context,
                                       int64_t number);
 
-/// The execution result code.
-enum evm_result_code {
+/// The execution status code.
+enum evm_status_code {
     EVM_SUCCESS = 0,               ///< Execution finished with success.
     EVM_FAILURE = 1,               ///< Generic execution failure.
     EVM_OUT_OF_GAS = 2,
@@ -107,7 +107,7 @@ enum evm_result_code {
     EVM_BAD_JUMP_DESTINATION = 4,
     EVM_STACK_OVERFLOW = 5,
     EVM_STACK_UNDERFLOW = 6,
-    EVM_REVERT = 7,  ///< Execution terminated with REVERT opcode.
+    EVM_REVERT = 7,                ///< Execution terminated with REVERT opcode.
 
     /// EVM implementation internal error.
     ///
@@ -132,7 +132,7 @@ typedef void (*evm_release_result_fn)(struct evm_result const* result);
 struct evm_result {
     /// The execution result code.
     /// FIXME: Rename to 'status' or 'status_code'.
-    enum evm_result_code code;
+    enum evm_status_code code;
 
     /// The amount of gas left after the execution.
     ///
@@ -295,13 +295,13 @@ typedef void (*evm_call_fn)(struct evm_result* result,
                             struct evm_context* context,
                             const struct evm_message* msg);
 
-/// The Host interface.
+/// The context interface.
 ///
 /// The set of all callback functions expected by EVM instances. This is C
-/// realisation of OOP interface (only virtual methods, no data).
+/// realisation of vtable for OOP interface (only virtual methods, no data).
 /// Host implementations SHOULD create constant singletons of this (similarly
 /// to vtables) to lower the maintenance and memory management cost.
-struct evm_host {
+struct evm_context_fn_table {
     evm_account_exists_fn account_exists;
     evm_get_storage_fn get_storage;
     evm_set_storage_fn set_storage;
@@ -325,8 +325,8 @@ struct evm_host {
 /// Optionally, The Host MAY include in the context additional data.
 struct evm_context {
 
-    /// Function table defining the context interface.
-    const struct evm_host* fn_table;
+    /// Function table defining the context interface (vtable).
+    const struct evm_context_fn_table* fn_table;
 };
 
 
@@ -434,6 +434,8 @@ struct evm_instance {
     ///
     /// For future use to detect ABI incompatibilities. The EVM-C ABI version
     /// represented by this file is in ::EVM_ABI_VERSION.
+    ///
+    /// @todo Consider removing this field.
     const int abi_version;
 
     /// Pointer to function destroying the EVM instance.
@@ -467,7 +469,6 @@ struct evm_instance {
 ///
 /// @return  EVM instance.
 /// @todo Specify if this function can return null pointer to indicate error.
-/// @todo Can we return const pointer?
 struct evm_instance* examplevm_create(void);
 
 

--- a/include/evm.h
+++ b/include/evm.h
@@ -111,8 +111,8 @@ enum evm_status_code {
 
     /// EVM implementation internal error.
     ///
-    /// FIXME: We should rethink reporting internal errors. One of the options
-    /// it to allow using any negative value to represent internal errors.
+    /// @todo We should rethink reporting internal errors. One of the options
+    ///       it to allow using any negative value to represent internal errors.
     EVM_INTERNAL_ERROR = -1,
 };
 
@@ -130,9 +130,8 @@ typedef void (*evm_release_result_fn)(struct evm_result const* result);
 
 /// The EVM code execution result.
 struct evm_result {
-    /// The execution result code.
-    /// FIXME: Rename to 'status' or 'status_code'.
-    enum evm_status_code code;
+    /// The execution status code.
+    enum evm_status_code status_code;
 
     /// The amount of gas left after the execution.
     ///

--- a/include/evm.h
+++ b/include/evm.h
@@ -437,6 +437,13 @@ typedef void (*evm_prepare_code_fn)(struct evm_instance* instance,
 ///
 /// Defines the base struct of the EVM implementation.
 struct evm_instance {
+
+    /// EVM-C ABI version implemented by the EVM instance.
+    ///
+    /// For future use to detect ABI incompatibilities. The EVM-C ABI version
+    /// represented by this file is in ::EVM_ABI_VERSION.
+    const int abi_version;
+
     /// Pointer to function destroying the EVM instance.
     evm_destroy_fn destroy;
 
@@ -463,11 +470,6 @@ struct evm_instance {
 ///
 /// Provides ABI protection and method to create an EVM instance.
 struct evm_factory {
-    /// EVM-C ABI version implemented by the EVM factory and instance.
-    ///
-    /// For future use to detect ABI incompatibilities. The EVM-C ABI version
-    /// represented by this file is in ::EVM_ABI_VERSION.
-    int abi_version;
 
     /// Pointer to function creating and initializing the EVM instance.
     evm_create_fn create;

--- a/include/evm.h
+++ b/include/evm.h
@@ -49,7 +49,7 @@ struct evm_uint256be {
 
 /// Big-endian 160-bit hash suitable for keeping an Ethereum address.
 /// TODO: Rename to "address".
-struct evm_uint160be {
+struct evm_address {
     /// The 20 bytes of the hash.
     uint8_t bytes[20];
 };
@@ -67,8 +67,8 @@ enum evm_flags {
 };
 
 struct evm_message {
-    struct evm_uint160be address;
-    struct evm_uint160be sender;
+    struct evm_address address;
+    struct evm_address sender;
     struct evm_uint256be value;
     const uint8_t* input;
     size_t input_size;
@@ -81,8 +81,8 @@ struct evm_message {
 
 struct evm_tx_context {
     struct evm_uint256be tx_gas_price;
-    struct evm_uint160be tx_origin;
-    struct evm_uint160be block_coinbase;
+    struct evm_address tx_origin;
+    struct evm_address block_coinbase;
     int64_t block_number;
     int64_t block_timestamp;
     int64_t block_gas_limit;
@@ -196,7 +196,7 @@ struct evm_result {
 /// @param      address  The address of the account the query is about.
 /// @return              1 if exists, 0 otherwise.
 typedef int (*evm_account_exists_fn)(struct evm_context* context,
-                                     const struct evm_uint160be* address);
+                                     const struct evm_address* address);
 
 /// Get storage callback function.
 ///
@@ -209,7 +209,7 @@ typedef int (*evm_account_exists_fn)(struct evm_context* context,
 /// @param      key      The index of the storage entry.
 typedef void (*evm_get_storage_fn)(struct evm_uint256be* result,
                                    struct evm_context* context,
-                                   const struct evm_uint160be* address,
+                                   const struct evm_address* address,
                                    const struct evm_uint256be* key);
 
 /// Set storage callback function.
@@ -222,7 +222,7 @@ typedef void (*evm_get_storage_fn)(struct evm_uint256be* result,
 /// @param key      The index of the storage entry.
 /// @param value    The value to be stored.
 typedef void (*evm_set_storage_fn)(struct evm_context* context,
-                                   const struct evm_uint160be* address,
+                                   const struct evm_address* address,
                                    const struct evm_uint256be* key,
                                    const struct evm_uint256be* value);
 
@@ -236,7 +236,7 @@ typedef void (*evm_set_storage_fn)(struct evm_context* context,
 /// @param      address  The address.
 typedef void (*evm_get_balance_fn)(struct evm_uint256be* result,
                                    struct evm_context* context,
-                                   const struct evm_uint160be* address);
+                                   const struct evm_address* address);
 
 /// Get code callback function.
 ///
@@ -251,7 +251,7 @@ typedef void (*evm_get_balance_fn)(struct evm_uint256be* result,
 /// @return                  The size of the code.
 typedef size_t (*evm_get_code_fn)(const uint8_t** result_code,
                                   struct evm_context* context,
-                                  const struct evm_uint160be* address);
+                                  const struct evm_address* address);
 
 /// Selfdestruct callback function.
 ///
@@ -262,8 +262,8 @@ typedef size_t (*evm_get_code_fn)(const uint8_t** result_code,
 /// @param beneficiary  The address where the remaining ETH is going to be
 ///                     transferred.
 typedef void (*evm_selfdestruct_fn)(struct evm_context* context,
-                                    const struct evm_uint160be* address,
-                                    const struct evm_uint160be* beneficiary);
+                                    const struct evm_address* address,
+                                    const struct evm_address* beneficiary);
 
 /// Log callback function.
 ///
@@ -278,7 +278,7 @@ typedef void (*evm_selfdestruct_fn)(struct evm_context* context,
 /// @param topics_count  The number of the topics. Valid values are between
 ///                      0 and 4 inclusively.
 typedef void (*evm_log_fn)(struct evm_context* context,
-                           const struct evm_uint160be* address,
+                           const struct evm_address* address,
                            const uint8_t* data,
                            size_t data_size,
                            const struct evm_uint256be topics[],

--- a/include/evmjit.h
+++ b/include/evmjit.h
@@ -17,10 +17,10 @@
 extern "C" {
 #endif
 
-/// Get EVMJIT instance.
+/// Create EVMJIT instance.
 ///
 /// @return  The EVMJIT instance.
-EXPORT struct evm_factory evmjit_get_factory(void);
+EXPORT struct evm_instance* evmjit_create(void);
 
 #if __cplusplus
 }

--- a/libevmjit/JIT.cpp
+++ b/libevmjit/JIT.cpp
@@ -23,7 +23,7 @@
 
 
 static_assert(sizeof(evm_uint256be) == 32, "evm_uint256be is too big");
-static_assert(sizeof(evm_uint160be) == 20, "evm_uint160be is too big");
+static_assert(sizeof(evm_address) == 20, "evm_address is too big");
 static_assert(sizeof(evm_result) == 64, "evm_result does not fit cache line");
 static_assert(sizeof(evm_message) <= 18*8, "evm_message not optimally packed");
 static_assert(offsetof(evm_message, code_hash) % 8 == 0, "evm_message.code_hash not aligned");
@@ -151,7 +151,7 @@ static int64_t call_v2(
 	evm_context* _ctx,
 	evm_call_kind _kind,
 	int64_t _gas,
-	evm_uint160be const* _address,
+	evm_address const* _address,
 	evm_uint256be const* _value,
 	uint8_t const* _inputData,
 	size_t _inputSize,

--- a/libevmjit/JIT.cpp
+++ b/libevmjit/JIT.cpp
@@ -141,7 +141,7 @@ public:
 
 	ExecFunc compile(evm_revision _rev, bool _staticCall, byte const* _code, uint64_t _codeSize, std::string const& _codeIdentifier);
 
-	evm_host const* host = nullptr;
+	evm_context_fn_table const* host = nullptr;
 
 	evm_message const* currentMsg = nullptr;
 	std::vector<uint8_t> returnBuffer;

--- a/libevmjit/JIT.cpp
+++ b/libevmjit/JIT.cpp
@@ -470,13 +470,14 @@ static void prepare_code(evm_instance* instance, evm_revision rev, uint32_t flag
 
 EXPORT evm_factory evmjit_get_factory()
 {
-	return {EVM_ABI_VERSION, create};
+	return {create};
 }
 
 }  // extern "C"
 
 JITImpl::JITImpl():
-		evm_instance({evmjit::destroy,
+		evm_instance({EVM_ABI_VERSION,
+		              evmjit::destroy,
 		              evmjit::execute,
 		              evmjit::get_code_status,
 		              evmjit::prepare_code,

--- a/libevmjit/JIT.cpp
+++ b/libevmjit/JIT.cpp
@@ -193,7 +193,7 @@ static int64_t call_v2(
 	*o_bufData = jit.returnBuffer.data();
 	*o_bufSize = jit.returnBuffer.size();
 
-	if (result.code != EVM_SUCCESS)
+	if (result.status_code != EVM_SUCCESS)
 		r |= EVM_CALL_FAILURE;
 
 	if (result.release)
@@ -378,7 +378,7 @@ static evm_result execute(evm_instance* instance, evm_context* context, evm_revi
 	ExecutionContext ctx{rt, context};
 
 	evm_result result;
-	result.code = EVM_SUCCESS;
+	result.status_code = EVM_SUCCESS;
 	result.gas_left = 0;
 	result.output_data = nullptr;
 	result.output_size = 0;
@@ -399,14 +399,14 @@ static evm_result execute(evm_instance* instance, evm_context* context, evm_revi
 
 	if (returnCode == ReturnCode::Revert)
 	{
-		result.code = EVM_REVERT;
+		result.status_code = EVM_REVERT;
 		result.gas_left = rt.gas;
 	}
 	else if (returnCode == ReturnCode::OutOfGas)
 	{
 		// EVMJIT does not provide information what exactly type of failure
 		// it was, so use generic EVM_FAILURE.
-		result.code = EVM_FAILURE;
+		result.status_code = EVM_FAILURE;
 	}
 	else
 	{

--- a/libevmjit/JIT.cpp
+++ b/libevmjit/JIT.cpp
@@ -337,7 +337,7 @@ bytes_ref ExecutionContext::getReturnData() const
 extern "C"
 {
 
-static evm_instance* create()
+EXPORT evm_instance* evmjit_create()
 {
 	// Let's always return the same instance. It's a bit of faking, but actually
 	// this might be a compliant implementation.
@@ -466,11 +466,6 @@ static void prepare_code(evm_instance* instance, evm_revision rev, uint32_t flag
 	auto execFunc = jit.compile(rev, staticCall, code, code_size, codeIdentifier);
 	if (execFunc) // FIXME: What with error?
 		jit.mapExecFunc(codeIdentifier, execFunc);
-}
-
-EXPORT evm_factory evmjit_get_factory()
-{
-	return {create};
 }
 
 }  // extern "C"

--- a/tests/test-evm.cpp
+++ b/tests/test-evm.cpp
@@ -3,7 +3,7 @@
 evm_result test_call_failure(int64_t gas)
 {
     evm_result result{};
-    result.code = EVM_FAILURE;
+    result.status_code = EVM_FAILURE;
     result.gas_left = gas;
     return result;
 }

--- a/tests/test-evmjit-standalone.c
+++ b/tests/test-evmjit-standalone.c
@@ -3,12 +3,12 @@
 
 int main()
 {
-    struct evm_factory factory = evmjit_get_factory();
-    if (EVM_ABI_VERSION != factory.abi_version)
+    struct evm_instance* instance = evmjit_create();
+    if (EVM_ABI_VERSION != instance->abi_version)
     {
         printf("Error: expected ABI version %u!\n", EVM_ABI_VERSION);
         return 1;
     }
-    printf("EVMJIT ABI version %u\n", factory.abi_version);
+    printf("EVMJIT ABI version %u\n", instance->abi_version);
     return 0;
 }


### PR DESCRIPTION
This is final change to EVM-C API +/- documentation fixes and small refactorings.

I reviewed the previous version by drawing the class diagram of it. I managed to reduce it from 4 classes: Host, Context, EVM, Factory to only 2: EVM and Context. Now it matches very simple OOP polymorphic desing, but it is hard to see in under big C overhead.

I'm not sure we should keep the `ABI_VERSION` field. It does not seem to be useful in near future.

The still missing piece is tracing.