### PR TITLE
EVM-C: create address in evm_result

### DIFF
--- a/examples/capi.c
+++ b/examples/capi.c
@@ -166,4 +166,6 @@ int main(int argc, char *argv[]) {
     if (result.release)
         result.release(&result);
     jit->destroy(jit);
+
+    return 0;
 }


### PR DESCRIPTION
Previously output buffer was used to transfer created contract address from Client to EVM. There was no conflicts there, but this required a bit of logic on EVM side: the output buffer must be copied to RETURDATA buffer always except the case of successful CREATE. 
The fact I did it wrong in EVMJIT is an indication that it was bad design decision.

This PR allocates a field in `evm_result` for an address to be returned. This field is only valid for successful CREATEs, otherwise it can contain other data specific to Client implementation.

Resolves https://github.com/ethereum/evmjit/issues/137.